### PR TITLE
Php7 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - hhvm
+  - 7.1
 
 before_script:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -18,15 +18,31 @@ More information at http://ec.europa.eu/taxation_customs/vies/faqvies.do#item16
 
 [![Travis-CI Build status](https://api.travis-ci.org/DragonBe/vies.png)](https://travis-ci.org/DragonBe/vies) [![SensioLabs Insights](https://insight.sensiolabs.com/projects/21b019ce-dd1d-4d16-8b74-880b9ee5e795/mini.png)](https://insight.sensiolabs.com/projects/21b019ce-dd1d-4d16-8b74-880b9ee5e795) [![CodeClimate Analysis](https://d3s6mut3hikguw.cloudfront.net/github/DragonBe/vies/badges/gpa.svg)](https://codeclimate.com/github/DragonBe/vies) [![CodeClimate CodeCoverage](https://d3s6mut3hikguw.cloudfront.net/github/DragonBe/vies/badges/coverage.svg)](https://codeclimate.com/github/DragonBe/vies) [![CodeShip CI](https://codeship.com/projects/304718e0-8d01-0132-6960-7671d147512f/status?branch=master)](https://codeship.com/projects/60548) [![Build Status](https://status.continuousphp.com/git-hub/DragonBe/vies?token=e8721fe8-0619-4789-9691-33021709f42f)](https://continuousphp.com/git-hub/DragonBe/vies)
 
-# Installation
+## Requirements
+
+[![PHP 7.1 Approved](http://blob.in2itvof.com/php/php-7.1/approved.png)](http://blob.in2itvof.com/php/php-7.1/approved.png)
+
+- ~~Min PHP version: 5.4~~ (EOL 3 Sep 2015)
+- ~~Min PHP version: 5.5~~ (EOL 21 Jul 2016)
+- Min supported PHP version: 5.6 (EOL 19 Jan 2017, Security updates **31 Dec 2018**) -&gt; only v1.0.x
+- Supported PHP version: 7.0 (EOL 3 Dec 2017, Security updates **3 Dec 2018**) -&gt; only v1.0.x
+- Recommended PHP version: 7.1 [**CURRENT**] (EOL 1 Dec 2018, Security updates **1 Dec 2019**
+- Extension: soap
+- Extension: pcntl
+
+Please read the [release notes](https://github.com/DragonBe/vies/releases) for details.
+
+## Installation
 
 This project is on [Packagist](https://packagist.org/packages/dragonbe/vies)!
 
 To install the latest stable version use `composer require dragonbe/vies`.
 
+**WARNING:** The latest version 2.0.0 will have no support for PHP 5 and PHP 7.0! Only PHP 7.1 and higher!
+
 To install specifically a version (e.g. 1.0.4), just add it to the command above, for example `composer require dragonbe/vies:1.0.4`
 
-# Usage
+## Usage
 
 ```php
 <?php
@@ -82,6 +98,6 @@ if (false === $vies->getHeartBeat()->isAlive()) {
 }
 ```
 
-# Licence
+## Licence
 
 DragonBe\Vies is released under the MIT Licence. See the bundled [LICENSE](LICENSE) file for details.

--- a/composer.json
+++ b/composer.json
@@ -25,20 +25,19 @@
         }
     },
     "require": {
-        "php": ">=5.4",
+        "php": ">=7.1",
         "ext-soap": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.7",
+        "ext-pcntl": "*",
+        "phpunit/phpunit": "^6.1",
         "phpunit/php-invoker": "^1.1",
-        "phploc/phploc": "^2.1",
-        "phpmd/phpmd": "^2.2",
-        "sebastian/phpcpd": "^2.0",
-        "pdepend/pdepend": "^2.1",
-        "squizlabs/php_codesniffer": "^2.3",
-        "phing/phing": "^2.11",
-        "codeclimate/php-test-reporter": "dev-master",
-        "phpdocumentor/phpdocumentor": "^2.8",
-        "ext-pcntl": "*"
+        "phploc/phploc": "^3.0",
+        "phpmd/phpmd": "^2.6",
+        "sebastian/phpcpd": "^3.0",
+        "pdepend/pdepend": "^2.5",
+        "squizlabs/php_codesniffer": "^3.0",
+        "phing/phing": "^2.16",
+        "codeclimate/php-test-reporter": "^0.4.4"
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ruleset name="VIES Coding Standard">
+    <description>VIES Coding Standard</description>
+
+    <!-- display progress -->
+    <arg value="p"/>
+    <arg name="colors"/>
+
+    <!-- inherit rules from: -->
+    <rule ref="PSR2"/>
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+    <rule ref="Generic.Formatting.SpaceAfterNot"/>
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+        <properties>
+            <property name="ignoreBlankLines" value="false"/>
+        </properties>
+    </rule>
+
+    <file>src</file>
+    <file>tests</file>
+</ruleset>

--- a/src/Vies/CheckVatResponse.php
+++ b/src/Vies/CheckVatResponse.php
@@ -23,7 +23,7 @@ namespace DragonBe\Vies;
  */
 class CheckVatResponse
 {
-    const VIES_DATETIME_FORMAT = 'Y-m-dP';
+    public const VIES_DATETIME_FORMAT = 'Y-m-dP';
 
     /**
      * @var string The country code for a member of the European Union

--- a/src/Vies/CheckVatResponse.php
+++ b/src/Vies/CheckVatResponse.php
@@ -114,7 +114,7 @@ class CheckVatResponse
      */
     public function setRequestDate(\DateTime $requestDate): CheckVatResponse
     {
-        if (!$requestDate instanceof \DateTime) {
+        if (! $requestDate instanceof \DateTime) {
             $date = substr($requestDate, 0, 10);
             $timezone = substr($requestDate, -6);
             $requestDate = new \DateTime($date, \DateTime::createFromFormat('O', $timezone)->getTimezone());
@@ -228,7 +228,7 @@ class CheckVatResponse
 
         $requiredFields = ['countryCode', 'vatNumber', 'requestDate', 'valid'];
         foreach ($requiredFields as $requiredField) {
-            if (!isset ($row->$requiredField)) {
+            if (! isset ($row->$requiredField)) {
                 throw new \InvalidArgumentException('Required field "' . $requiredField . '" is missing');
             }
         }
@@ -260,7 +260,7 @@ class CheckVatResponse
      */
     public function toArray(): array
     {
-        return array (
+        return  [
             'countryCode' => $this->getCountryCode(),
             'vatNumber'   => $this->getVatNumber(),
             'requestDate' => $this->getRequestDate()->format('Y-m-d'),
@@ -268,6 +268,6 @@ class CheckVatResponse
             'name'        => $this->getName(),
             'address'     => $this->getAddress(),
             'identifier'  => $this->getIdentifier()
-        );
+        ];
     }
 }

--- a/src/Vies/CheckVatResponse.php
+++ b/src/Vies/CheckVatResponse.php
@@ -225,6 +225,14 @@ class CheckVatResponse
         if (is_array($row)) {
             $row = new \ArrayObject($row, \ArrayObject::ARRAY_AS_PROPS);
         }
+
+        $requiredFields = ['countryCode', 'vatNumber', 'requestDate', 'valid'];
+        foreach ($requiredFields as $requiredField) {
+            if (!isset ($row->$requiredField)) {
+                throw new \InvalidArgumentException('Required field "' . $requiredField . '" is missing');
+            }
+        }
+
         // required parameters
         $this->setCountryCode($row->countryCode)
              ->setVatNumber($row->vatNumber)

--- a/src/Vies/CheckVatResponse.php
+++ b/src/Vies/CheckVatResponse.php
@@ -57,7 +57,7 @@ class CheckVatResponse
     /**
      * Constructor for this response object
      *
-     * @param null|\StdClass $params
+     * @param null|array|\StdClass $params
      */
     public function __construct($params = null)
     {
@@ -71,7 +71,7 @@ class CheckVatResponse
      * @param string $countryCode
      * @return \DragonBe\Vies\CheckVatResponse
      */
-    public function setCountryCode($countryCode)
+    public function setCountryCode(string $countryCode): CheckVatResponse
     {
         $this->countryCode = (string) $countryCode;
         return $this;
@@ -82,7 +82,7 @@ class CheckVatResponse
      *
      * @return string
      */
-    public function getCountryCode()
+    public function getCountryCode(): string
     {
         return $this->countryCode;
     }
@@ -92,7 +92,7 @@ class CheckVatResponse
      * @param string $vatNumber
      * @return \DragonBe\Vies\CheckVatResponse
      */
-    public function setVatNumber($vatNumber)
+    public function setVatNumber(string $vatNumber): CheckVatResponse
     {
         $this->vatNumber = (string) $vatNumber;
         return $this;
@@ -102,17 +102,17 @@ class CheckVatResponse
      *
      * @return string
      */
-    public function getVatNumber()
+    public function getVatNumber(): string
     {
         return $this->vatNumber;
     }
     /**
      * Sets the date- and timestamp when the VIES service response was created
      *
-     * @param string $requestDate
+     * @param \DateTime $requestDate
      * @return \DragonBe\Vies\CheckVatResponse
      */
-    public function setRequestDate($requestDate)
+    public function setRequestDate(\DateTime $requestDate): CheckVatResponse
     {
         if (!$requestDate instanceof \DateTime) {
             $date = substr($requestDate, 0, 10);
@@ -127,7 +127,7 @@ class CheckVatResponse
      *
      * @return \DateTime
      */
-    public function getRequestDate()
+    public function getRequestDate(): \DateTime
     {
         if (null === $this->requestDate) {
             $this->requestDate = new \DateTime();
@@ -140,7 +140,7 @@ class CheckVatResponse
      * @param bool $flag
      * @return \DragonBe\Vies\CheckVatResponse
      */
-    public function setValid($flag)
+    public function setValid(bool $flag): CheckVatResponse
     {
         $this->valid = (boolean) $flag;
         return $this;
@@ -150,7 +150,7 @@ class CheckVatResponse
      *
      * @return bool
      */
-    public function isValid()
+    public function isValid(): bool
     {
         return $this->valid;
     }
@@ -160,7 +160,7 @@ class CheckVatResponse
      * @param string $name
      * @return \DragonBe\Vies\CheckVatResponse
      */
-    public function setName($name)
+    public function setName(string $name): CheckVatResponse
     {
         $this->name = (string) $name;
         return $this;
@@ -170,7 +170,7 @@ class CheckVatResponse
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -180,7 +180,7 @@ class CheckVatResponse
      * @param string $address
      * @return \DragonBe\Vies\CheckVatResponse
      */
-    public function setAddress($address)
+    public function setAddress(string $address): CheckVatResponse
     {
         $this->address = (string) $address;
         return $this;
@@ -190,7 +190,7 @@ class CheckVatResponse
      *
      * @return string
      */
-    public function getAddress()
+    public function getAddress(): string
     {
         return $this->address;
     }
@@ -198,10 +198,10 @@ class CheckVatResponse
     /**
      * Sets request Identifier
      *
-     * @param $identifier
+     * @param string $identifier
      * @return \DragonBe\Vies\CheckVatResponse
      */
-    public function setIdentifier($identifier)
+    public function setIdentifier(string $identifier): CheckVatResponse
     {
         $this->identifier = (string)$identifier;
         return $this;
@@ -209,9 +209,9 @@ class CheckVatResponse
     /**
      * get requerst Identifier
      *
-     * @return mixed
+     * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return $this->identifier;
     }
@@ -252,7 +252,13 @@ class CheckVatResponse
             ? $this->setIdentifier($row->requestIdentifier)
             : $this->setIdentifier('');
     }
-    public function toArray()
+
+    /**
+     * Return this object as an array
+     *
+     * @return array
+     */
+    public function toArray(): array
     {
         return array (
             'countryCode' => $this->getCountryCode(),

--- a/src/Vies/HeartBeat.php
+++ b/src/Vies/HeartBeat.php
@@ -46,7 +46,7 @@ class HeartBeat
      * @param string|null $host
      * @param int $port
      */
-    function __construct($host = null, $port = 80)
+    public function __construct($host = null, $port = 80)
     {
         if (null !== $host) {
             $this->setHost($host);

--- a/src/Vies/HeartBeat.php
+++ b/src/Vies/HeartBeat.php
@@ -46,7 +46,7 @@ class HeartBeat
      * @param string|null $host
      * @param int $port
      */
-    public function __construct($host = null, $port = 80)
+    public function __construct(? string $host = null, int $port = 80)
     {
         if (null !== $host) {
             $this->setHost($host);
@@ -57,7 +57,7 @@ class HeartBeat
     /**
      * @return string
      */
-    public function getHost()
+    public function getHost(): string
     {
         if (null === $this->host) {
             throw new \DomainException('A host is required');
@@ -69,7 +69,7 @@ class HeartBeat
      * @param string $host
      * @return HeartBeat
      */
-    public function setHost($host)
+    public function setHost(string $host): HeartBeat
     {
         $this->host = $host;
         return $this;
@@ -78,7 +78,7 @@ class HeartBeat
     /**
      * @return int
      */
-    public function getPort()
+    public function getPort(): int
     {
         return $this->port;
     }
@@ -87,7 +87,7 @@ class HeartBeat
      * @param int $port
      * @return HeartBeat
      */
-    public function setPort($port)
+    public function setPort(int $port): heartbeat
     {
         $this->port = $port;
         return $this;
@@ -95,8 +95,10 @@ class HeartBeat
 
     /**
      * Checks if the VIES service is online and available
+     *
+     * @return bool
      */
-    public function isAlive()
+    public function isAlive(): bool
     {
 
         $status = $this->connect($this->getHost(), $this->getPort());
@@ -109,16 +111,17 @@ class HeartBeat
     /**
      * Make a connection outwards to test an online service
      *
-     * @param $host
-     * @param $port
-     * @return bool|resource
+     * @param string $host
+     * @param int $port
+     * @return bool
      * @private
      */
-    private function connect($host, $port)
+    private function connect(string $host, int $port): bool
     {
         $status = HeartBeat::$testingServiceIsUp;
         if (false === HeartBeat::$testingEnabled) {
-            $status = fsockopen($host, $port);
+            $resource = fsockopen($host, $port);
+            return (false !== $resource);
         }
         return $status;
     }

--- a/src/Vies/Validator/ValidatorBG.php
+++ b/src/Vies/Validator/ValidatorBG.php
@@ -42,12 +42,12 @@ class ValidatorBG extends ValidatorAbstract
             return false;
         }
 
-        $weights = array(1, 2, 3, 4, 5, 6, 7, 8);
+        $weights = [1, 2, 3, 4, 5, 6, 7, 8];
         $checksum = (int)$vatNumber[8];
         $checkval = $this->sumWeights($weights, $vatNumber);
 
         if ($checkval % 11 == 10) {
-            $weights = array(3, 4, 5, 6, 7, 8, 9, 10);
+            $weights = [3, 4, 5, 6, 7, 8, 9, 10];
             $checkval = $this->sumWeights($weights, $vatNumber);
 
             $checkval = ($checkval % 11) == 10 ? 0 : ($checkval % 11);

--- a/src/Vies/Validator/ValidatorCY.php
+++ b/src/Vies/Validator/ValidatorCY.php
@@ -41,11 +41,11 @@ class ValidatorCY extends ValidatorAbstract
             return false;
         }
 
-        if (!in_array($vatNumber[0], $this->allowedC1)) {
+        if (! in_array($vatNumber[0], $this->allowedC1)) {
             return false;
         }
 
-        if (!ctype_alpha($vatNumber[8])) {
+        if (! ctype_alpha($vatNumber[8])) {
             return false;
         }
 

--- a/src/Vies/Validator/ValidatorCZ.php
+++ b/src/Vies/Validator/ValidatorCZ.php
@@ -49,7 +49,7 @@ class ValidatorCZ extends ValidatorAbstract
             return false;
         }
 
-        $weights = array(8, 7, 6, 5, 4, 3, 2);
+        $weights = [8, 7, 6, 5, 4, 3, 2];
         $checksum = (int)$vatNumber[7];
         $checkbase = $this->sumWeights($weights, $vatNumber);
 

--- a/src/Vies/Validator/ValidatorDK.php
+++ b/src/Vies/Validator/ValidatorDK.php
@@ -35,7 +35,7 @@ class ValidatorDK extends ValidatorAbstract
         if (strlen($vatNumber) != 8) {
             return false;
         }
-        $weights = array(2, 7, 6, 5, 4, 3, 2, 1);
+        $weights = [2, 7, 6, 5, 4, 3, 2, 1];
         $checksum = $this->sumWeights($weights, $vatNumber);
 
         if (($checksum % 11) > 0) {

--- a/src/Vies/Validator/ValidatorEE.php
+++ b/src/Vies/Validator/ValidatorEE.php
@@ -37,7 +37,7 @@ class ValidatorEE extends ValidatorAbstract
             return false;
         }
 
-        $weights = array(3, 7, 1, 3, 7, 1, 3, 7);
+        $weights = [3, 7, 1, 3, 7, 1, 3, 7];
         $checksum = (int)$vatNumber[8];
         $checkval = $this->sumWeights($weights, $vatNumber);
 
@@ -48,6 +48,5 @@ class ValidatorEE extends ValidatorAbstract
         }
 
         return true;
-
     }
 }

--- a/src/Vies/Validator/ValidatorEL.php
+++ b/src/Vies/Validator/ValidatorEL.php
@@ -37,7 +37,7 @@ class ValidatorEL extends ValidatorAbstract
         }
 
         $checksum = $vatNumber[8];
-        $weights = array(256, 128, 64, 32, 16, 8, 4, 2);
+        $weights = [256, 128, 64, 32, 16, 8, 4, 2];
         $checkval = $this->sumWeights($weights, $vatNumber);
         $checkval = ($checkval % 11) > 9 ? 0 : ($checkval % 11);
 

--- a/src/Vies/Validator/ValidatorES.php
+++ b/src/Vies/Validator/ValidatorES.php
@@ -83,7 +83,7 @@ class ValidatorES extends ValidatorAbstract
             return false;
         }
 
-        if (!is_numeric(substr($vatNumber, 1, 6))) {
+        if (! is_numeric(substr($vatNumber, 1, 6))) {
             return false;
         }
 
@@ -93,11 +93,9 @@ class ValidatorES extends ValidatorAbstract
         if (ctype_alpha($checksum) && in_array($fieldC1, $this->allowedC1Alphabetic)) {
             // Juridical entities other than national ones
             $checkval = $this->validateJuridical($vatNumber);
-
         } elseif (ctype_digit($checksum) && in_array($fieldC1, $this->allowedC1Numeric)) {
             // National juridical entities
             $checkval = $this->validateNational($vatNumber);
-
         } else {
             return false;
         }

--- a/src/Vies/Validator/ValidatorFI.php
+++ b/src/Vies/Validator/ValidatorFI.php
@@ -38,7 +38,7 @@ class ValidatorFI extends ValidatorAbstract
         }
 
         $checksum = (int)$vatNumber[7];
-        $weights = array(7, 9, 10, 5, 8, 4, 2);
+        $weights = [7, 9, 10, 5, 8, 4, 2];
         $checkval = $this->sumWeights($weights, $vatNumber);
 
         if (11 - ($checkval % 11) != $checksum) {

--- a/src/Vies/Validator/ValidatorGB.php
+++ b/src/Vies/Validator/ValidatorGB.php
@@ -58,7 +58,7 @@ class ValidatorGB extends ValidatorAbstract
             return false;
         }
 
-        $weights = array(8, 7, 6, 5, 4, 3, 2);
+        $weights = [8, 7, 6, 5, 4, 3, 2];
         $checkval = $this->sumWeights($weights, $vatNumber);
         $checkval += (int)substr($vatNumber, 7, 2);
 

--- a/src/Vies/Validator/ValidatorHU.php
+++ b/src/Vies/Validator/ValidatorHU.php
@@ -37,7 +37,7 @@ class ValidatorHU extends ValidatorAbstract
             return false;
         }
 
-        $weights = array(9, 7, 3, 1, 9, 7, 3);
+        $weights = [9, 7, 3, 1, 9, 7, 3];
         $checksum = (int)$vatNumber[7];
         $checkval = $this->sumWeights($weights, $vatNumber);
 

--- a/src/Vies/Validator/ValidatorIE.php
+++ b/src/Vies/Validator/ValidatorIE.php
@@ -30,7 +30,7 @@ class ValidatorIE extends ValidatorAbstract
             return false;
         }
 
-        if (!$this->validateIENew($vatNumber) && !$this->validateIEOld($vatNumber)) {
+        if (! $this->validateIENew($vatNumber) && ! $this->validateIEOld($vatNumber)) {
             return false;
         }
 
@@ -43,7 +43,7 @@ class ValidatorIE extends ValidatorAbstract
      */
     private function validateIEOld($vatNumber)
     {
-        $transform = array('0', substr($vatNumber, 2, 5), $vatNumber[0], $vatNumber[7]);
+        $transform = ['0', substr($vatNumber, 2, 5), $vatNumber[0], $vatNumber[7]];
         $vat_id = join('', $transform);
 
         return $this->validateIENew($vat_id);

--- a/src/Vies/Validator/ValidatorIT.php
+++ b/src/Vies/Validator/ValidatorIT.php
@@ -45,7 +45,7 @@ class ValidatorIT extends ValidatorAbstract
         $checksum = (int)substr($vatNumber, -1);
         $Sum1 = $Sum2 = 0;
         for ($i = 1; $i <= 10; $i++) {
-            if (!$this->isEven($i)) {
+            if (! $this->isEven($i)) {
                 $Sum1 += $vatNumber[$i - 1];
             } else {
                 $Sum2 += (int)($vatNumber[$i - 1] / 5) + ((2 * $vatNumber[$i - 1]) % 10);

--- a/src/Vies/Validator/ValidatorLT.php
+++ b/src/Vies/Validator/ValidatorLT.php
@@ -58,12 +58,12 @@ class ValidatorLT extends ValidatorAbstract
             return false;
         }
 
-        $weights = array(1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2);
+        $weights = [1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2];
         $checksum = (int)$vatNumber[11];
         $checkval = $this->sumWeights($weights, $vatNumber);
 
         if (($checkval % 11) == 10) {
-            $weights = array(3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4);
+            $weights = [3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4];
             $checkval = $this->sumWeights($weights, $vatNumber);
             $checkval = ($checkval % 11 == 10) ? 0 : $checkval % 11;
 
@@ -79,12 +79,12 @@ class ValidatorLT extends ValidatorAbstract
             return false;
         }
 
-        $weights = array(1, 2, 3, 4, 5, 6, 7, 8);
+        $weights = [1, 2, 3, 4, 5, 6, 7, 8];
         $checksum = (int)$vatNumber[8];
         $checkval = $this->sumWeights($weights, $vatNumber);
 
         if (($checkval % 11) == 10) {
-            $weights = array(3, 4, 5, 6, 7, 8, 9, 1);
+            $weights = [3, 4, 5, 6, 7, 8, 9, 1];
             $checkval = $this->sumWeights($weights, $vatNumber);
             $checkval = ($checkval % 11 == 10) ? 0 : $checkval % 11;
 

--- a/src/Vies/Validator/ValidatorLV.php
+++ b/src/Vies/Validator/ValidatorLV.php
@@ -43,7 +43,7 @@ class ValidatorLV extends ValidatorAbstract
             return false;
         }
 
-        $weights = array(9, 1, 4, 8, 3, 10, 2, 5, 7, 6);
+        $weights = [9, 1, 4, 8, 3, 10, 2, 5, 7, 6];
         $checksum = (int)substr($vatNumber, -1);
         $checkval = $this->sumWeights($weights, $vatNumber);
         $checkval = 3 - ($checkval % 11);

--- a/src/Vies/Validator/ValidatorMT.php
+++ b/src/Vies/Validator/ValidatorMT.php
@@ -42,11 +42,11 @@ class ValidatorMT extends ValidatorAbstract
             return false;
         }
 
-        $weights = array(3, 4, 6, 7, 8, 9);
+        $weights = [3, 4, 6, 7, 8, 9];
         $checksum = (int)substr($vatNumber, -2, 2);
         $checkval = $this->sumWeights($weights, $vatNumber);
         $checkval = intval(37 - ($checkval % 37));
-        
+
         if ($checkval != $checksum) {
             return false;
         }

--- a/src/Vies/Validator/ValidatorNL.php
+++ b/src/Vies/Validator/ValidatorNL.php
@@ -51,10 +51,10 @@ class ValidatorNL extends ValidatorAbstract
         }
 
         $checksum = (int)$vatNumber[8];
-        $weights = array(9, 8, 7, 6, 5, 4, 3, 2);
+        $weights = [9, 8, 7, 6, 5, 4, 3, 2];
         $checkval = $this->sumWeights($weights, $vatNumber);
         $checkval = ($checkval % 11) > 9 ? 0 : ($checkval % 11);
-        
+
         if ($checkval != $checksum) {
             return false;
         }

--- a/src/Vies/Validator/ValidatorPL.php
+++ b/src/Vies/Validator/ValidatorPL.php
@@ -37,7 +37,7 @@ class ValidatorPL extends ValidatorAbstract
             return false;
         }
 
-        $weights = array(6, 5, 7, 2, 3, 4, 5, 6, 7);
+        $weights = [6, 5, 7, 2, 3, 4, 5, 6, 7];
         $checksum = (int)$vatNumber[9];
         $checkval = $this->sumWeights($weights, $vatNumber);
 

--- a/src/Vies/Validator/ValidatorPT.php
+++ b/src/Vies/Validator/ValidatorPT.php
@@ -37,7 +37,7 @@ class ValidatorPT extends ValidatorAbstract
         }
 
         $checksum = (int)$vatNumber[8];
-        $weights = array(9, 8, 7, 6, 5, 4, 3, 2);
+        $weights = [9, 8, 7, 6, 5, 4, 3, 2];
         $checkval = $this->sumWeights($weights, $vatNumber);
 
         $checkval = (11 - ($checkval % 11)) > 9 ? 0 : (11 - ($checkval % 11));

--- a/src/Vies/Validator/ValidatorRO.php
+++ b/src/Vies/Validator/ValidatorRO.php
@@ -43,7 +43,7 @@ class ValidatorRO extends ValidatorAbstract
         $vatNumber = str_pad($vatNumber, 10, "0", STR_PAD_LEFT);
 
         $checksum = (int)$vatNumber[9];
-        $weights = array(7, 5, 3, 2, 1, 7, 5, 3, 2);
+        $weights = [7, 5, 3, 2, 1, 7, 5, 3, 2];
         $checkval = $this->sumWeights($weights, $vatNumber);
 
         $checkval = ($checkval * 10) % 11;

--- a/src/Vies/Validator/ValidatorSI.php
+++ b/src/Vies/Validator/ValidatorSI.php
@@ -44,7 +44,7 @@ class ValidatorSI extends ValidatorAbstract
         }
 
         $checksum = (int)$vatNumber[7];
-        $weights = array(8, 7, 6, 5, 4, 3, 2);
+        $weights = [8, 7, 6, 5, 4, 3, 2];
         $checkval = $this->sumWeights($weights, $vatNumber);
         $checkval = ($checkval % 11) == 10 ? 0 : 11 - ($checkval % 11);
 

--- a/src/Vies/Vies.php
+++ b/src/Vies/Vies.php
@@ -20,7 +20,8 @@ namespace DragonBe\Vies;
  * MS_UNAVAILABLE            : The Member State service is unavailable. Try again later or with another Member State.
  * SERVER_BUSY               : The service can not process your request. Try again later.
  * SERVICE_UNAVAILABLE       : The SOAP service is unavailable, try again later.
- * TIMEOUT                   : The Member State service could not be reach in time, try again later or with another Member State
+ * TIMEOUT                   : The Member State service could not be reach in time, try again later or with another
+ *                             Member State
  *
  * GLOBAL_MAX_CONCURRENT_REQ : The number of concurrent requests is more than the VIES service allows.
  * MS_MAX_CONCURRENT_REQ     : Same as MS_MAX_CONCURRENT_REQ.
@@ -207,12 +208,12 @@ class Vies
      */
     public function validateVat($countryCode, $vatNumber, $requesterCountryCode = null, $requesterVatNumber = null)
     {
-        if (!array_key_exists($countryCode, self::listEuropeanCountries())) {
+        if (! array_key_exists($countryCode, self::listEuropeanCountries())) {
             throw new ViesException(sprintf('Invalid country code "%s" provided', $countryCode));
         }
         $vatNumber = self::filterVat($vatNumber);
 
-        if (!$this->validateVatSum($countryCode, $vatNumber)) {
+        if (! $this->validateVatSum($countryCode, $vatNumber)) {
             $params = new \StdClass();
             $params->countryCode = $countryCode;
             $params->vatNumber = $vatNumber;
@@ -222,14 +223,16 @@ class Vies
             return new CheckVatResponse($params);
         }
 
-        $requestParams = array(
+        $requestParams = [
             'countryCode' => $countryCode,
             'vatNumber' => $vatNumber
-        );
+        ];
 
         if ($requesterCountryCode && $requesterVatNumber) {
-            if (!array_key_exists($requesterCountryCode, self::listEuropeanCountries())) {
-                throw new ViesException(sprintf('Invalid requestor country code "%s" provided', $requesterCountryCode));
+            if (! array_key_exists($requesterCountryCode, self::listEuropeanCountries())) {
+                throw new ViesException(
+                    sprintf('Invalid requestor country code "%s" provided', $requesterCountryCode)
+                );
             }
             $requesterVatNumber = self::filterVat($requesterVatNumber);
 
@@ -240,14 +243,14 @@ class Vies
         try {
             $response = $this->getSoapClient()->__soapCall(
                 'checkVatApprox',
-                array(
+                [
                     $requestParams
-                )
+                ]
             );
         } catch (SoapFault $e) {
             $message = sprintf('Back-end VIES service cannot validate the VAT number "%s%s" at this moment. '
-                             . 'The service responded with the critical error "%s". This is probably a temporary problem. '
-                             . 'Please try again later.',
+                             . 'The service responded with the critical error "%s". This is probably a temporary '
+                             . 'problem. Please try again later.',
                                $countryCode, $vatNumber, $e->getMessage());
             throw new ViesServiceException($message);
         }
@@ -285,7 +288,7 @@ class Vies
      */
     public static function filterVat($vatNumber)
     {
-        return str_replace(array(' ', '.', '-'), '', $vatNumber);
+        return str_replace([' ', '.', '-'], '', $vatNumber);
     }
 
     /**

--- a/src/Vies/Vies.php
+++ b/src/Vies/Vies.php
@@ -41,10 +41,10 @@ use SoapFault;
  */
 class Vies
 {
-    const VIES_PROTO = 'http';
-    const VIES_DOMAIN = 'ec.europa.eu';
-    const VIES_WSDL = '/taxation_customs/vies/checkVatService.wsdl';
-    const VIES_EU_COUNTRY_TOTAL = 28;
+    public const VIES_PROTO = 'http';
+    public const VIES_DOMAIN = 'ec.europa.eu';
+    public const VIES_WSDL = '/taxation_customs/vies/checkVatService.wsdl';
+    public const VIES_EU_COUNTRY_TOTAL = 28;
 
     /**
      * @var \SoapClient
@@ -72,7 +72,7 @@ class Vies
      *
      * @return \SoapClient
      */
-    public function getSoapClient()
+    public function getSoapClient(): \SoapClient
     {
         if (null === $this->soapClient) {
             $this->soapClient = new \SoapClient(
@@ -92,7 +92,7 @@ class Vies
      * @param \SoapClient $soapClient
      * @return Vies
      */
-    public function setSoapClient($soapClient)
+    public function setSoapClient(\SoapClient $soapClient): Vies
     {
         $this->soapClient = $soapClient;
 
@@ -104,7 +104,7 @@ class Vies
      *
      * @return string
      */
-    public function getWsdl()
+    public function getWsdl(): string
     {
         if (null === $this->wsdl) {
             $this->wsdl = sprintf(
@@ -125,7 +125,7 @@ class Vies
      * @return Vies
      * @example http://ec.europa.eu//taxation_customs/vies/checkVatService.wsdl
      */
-    public function setWsdl($wsdl)
+    public function setWsdl(string $wsdl): Vies
     {
         $this->wsdl = $wsdl;
 
@@ -137,7 +137,7 @@ class Vies
      *
      * @return array
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         if (null === $this->options) {
             $this->options = [];
@@ -153,7 +153,7 @@ class Vies
      * @return Vies
      * @link http://php.net/manual/en/soapclient.soapclient.php
      */
-    public function setOptions($options)
+    public function setOptions(array $options): Vies
     {
         $this->options = $options;
 
@@ -166,7 +166,7 @@ class Vies
      *
      * @return HeartBeat
      */
-    public function getHeartBeat()
+    public function getHeartBeat(): HeartBeat
     {
         if (null === $this->heartBeat) {
             $this->setHeartBeat(
@@ -205,8 +205,9 @@ class Vies
      * identification) of a registered company
      * @return CheckVatResponse
      * @throws ViesException
+     * @throws ViesServiceException
      */
-    public function validateVat($countryCode, $vatNumber, $requesterCountryCode = null, $requesterVatNumber = null)
+    public function validateVat(string $countryCode, string $vatNumber, string $requesterCountryCode = '', string $requesterVatNumber = '')
     {
         if (! array_key_exists($countryCode, self::listEuropeanCountries())) {
             throw new ViesException(sprintf('Invalid country code "%s" provided', $countryCode));
@@ -269,7 +270,7 @@ class Vies
      * identification) of a registered company
      * @return bool
      */
-    public function validateVatSum($countryCode, $vatNumber)
+    public function validateVatSum(string $countryCode, string $vatNumber): bool
     {
         $className = __NAMESPACE__ . '\\Validator\\Validator' . $countryCode;
         /** @var Validator\ValidatorInterface $instance */
@@ -286,7 +287,7 @@ class Vies
      * @return string
      * @static
      */
-    public static function filterVat($vatNumber)
+    public static function filterVat(string $vatNumber): string
     {
         return str_replace([' ', '.', '-'], '', $vatNumber);
     }
@@ -296,7 +297,7 @@ class Vies
      *
      * @return array
      */
-    public static function listEuropeanCountries()
+    public static function listEuropeanCountries(): array
     {
         return [
             'AT' => 'Austria',

--- a/src/Vies/Vies.php
+++ b/src/Vies/Vies.php
@@ -207,8 +207,13 @@ class Vies
      * @throws ViesException
      * @throws ViesServiceException
      */
-    public function validateVat(string $countryCode, string $vatNumber, string $requesterCountryCode = '', string $requesterVatNumber = '')
-    {
+    public function validateVat(
+        string $countryCode,
+        string $vatNumber,
+        string $requesterCountryCode = '',
+        string $requesterVatNumber = ''
+    ) {
+
         if (! array_key_exists($countryCode, self::listEuropeanCountries())) {
             throw new ViesException(sprintf('Invalid country code "%s" provided', $countryCode));
         }

--- a/src/Vies/Vies.php
+++ b/src/Vies/Vies.php
@@ -251,6 +251,8 @@ class Vies
                                $countryCode, $vatNumber, $e->getMessage());
             throw new ViesServiceException($message);
         }
+        // Soap returns "yyyy-mm-dd+hh:mm" so we need to convert it
+        $response->requestDate = new \DateTime(str_replace('+', ' ', $response->requestDate));
 
         return new CheckVatResponse($response);
     }

--- a/tests/Vies/CheckVatResponseTest.php
+++ b/tests/Vies/CheckVatResponseTest.php
@@ -48,10 +48,10 @@ class CheckVatResponseTest extends TestCase
 
     public function validationProvider()
     {
-        return array (
-            array (true),
-            array (false)
-        );
+        return  [
+             [true],
+             [false]
+        ];
     }
 
     /**
@@ -201,8 +201,13 @@ class CheckVatResponseTest extends TestCase
      * @covers \DragonBe\Vies\CheckVatResponse::setIdentifier
      * @covers \DragonBe\Vies\CheckVatResponse::getIdentifier
      */
-    public function testResponseContainsEmptyValuesWithOnlyRequiredArguments($countryCode, $vatNumber, $requestDate, $valid)
-    {
+    public function testResponseContainsEmptyValuesWithOnlyRequiredArguments(
+        $countryCode,
+        $vatNumber,
+        $requestDate,
+        $valid
+    ) {
+
         $expectedResult = [
             'countryCode' => $countryCode,
             'vatNumber' => $vatNumber,

--- a/tests/Vies/CheckVatResponseTest.php
+++ b/tests/Vies/CheckVatResponseTest.php
@@ -1,9 +1,12 @@
 <?php
+declare (strict_types=1);
+
 namespace DragonBe\Test\Vies;
 
 use DragonBe\Vies\CheckVatResponse;
+use PHPUnit\Framework\TestCase;
 
-class CheckVatResponseTest extends \PHPUnit_Framework_TestCase
+class CheckVatResponseTest extends TestCase
 {
     /**
      * @param bool $isValid

--- a/tests/Vies/CheckVatResponseTest.php
+++ b/tests/Vies/CheckVatResponseTest.php
@@ -22,7 +22,7 @@ class CheckVatResponseTest extends TestCase
         $response = new \stdClass();
         $response->countryCode = 'BE';
         $response->vatNumber = '123456749';
-        $response->requestDate = date('Y-m-dP');
+        $response->requestDate = new \DateTime(date('Y-m-dP'));
         $response->valid = $isValid;
         $response->traderName = 'Testing Corp N.V.';
         $response->traderAddress = 'MARKT 1' . PHP_EOL . '1000  BRUSSEL';
@@ -38,7 +38,7 @@ class CheckVatResponseTest extends TestCase
         return [
             'countryCode' => 'BE',
             'vatNumber'   => '123456749',
-            'requestDate' => date('Y-m-dP'),
+            'requestDate' => new \DateTime(date('Y-m-dP')),
             'valid'       => $isValid,
             'traderName'        => 'Testing Corp N.V.',
             'traderAddress'     => 'MARKT 1' . PHP_EOL . '1000  BRUSSEL',
@@ -81,7 +81,7 @@ class CheckVatResponseTest extends TestCase
         $checkVatResponse = new CheckVatResponse($response);
         $this->assertSame($response->countryCode, $checkVatResponse->getCountryCode());
         $this->assertSame($response->vatNumber, $checkVatResponse->getVatNumber());
-        $this->assertSame($response->requestDate, $checkVatResponse->getRequestDate()->format(CheckVatResponse::VIES_DATETIME_FORMAT));
+        $this->assertSame($response->requestDate, $checkVatResponse->getRequestDate());
         $this->assertSame($response->valid, $checkVatResponse->isValid());
         $this->assertSame($response->traderName, $checkVatResponse->getName());
         $this->assertSame($response->traderAddress, $checkVatResponse->getAddress());
@@ -114,7 +114,7 @@ class CheckVatResponseTest extends TestCase
         $checkVatResponse = new CheckVatResponse($response);
         $this->assertSame($response->countryCode, $checkVatResponse->getCountryCode());
         $this->assertSame($response->vatNumber, $checkVatResponse->getVatNumber());
-        $this->assertSame($response->requestDate, $checkVatResponse->getRequestDate()->format(CheckVatResponse::VIES_DATETIME_FORMAT));
+        $this->assertSame($response->requestDate, $checkVatResponse->getRequestDate());
         $this->assertSame($response->valid, $checkVatResponse->isValid());
         $this->assertSame($response->requestIdentifier, $checkVatResponse->getIdentifier());
         $this->assertSame('---', $checkVatResponse->getName());
@@ -146,7 +146,7 @@ class CheckVatResponseTest extends TestCase
         $checkVatResponse = new CheckVatResponse($response);
         $this->assertSame($response['countryCode'], $checkVatResponse->getCountryCode());
         $this->assertSame($response['vatNumber'], $checkVatResponse->getVatNumber());
-        $this->assertSame($response['requestDate'], $checkVatResponse->getRequestDate()->format(CheckVatResponse::VIES_DATETIME_FORMAT));
+        $this->assertSame($response['requestDate'], $checkVatResponse->getRequestDate());
         $this->assertSame($response['valid'], $checkVatResponse->isValid());
         $this->assertSame($response['traderName'], $checkVatResponse->getName());
         $this->assertSame($response['traderAddress'], $checkVatResponse->getAddress());
@@ -215,7 +215,7 @@ class CheckVatResponseTest extends TestCase
         $vatResponse = new CheckVatResponse([
             'countryCode' => $countryCode,
             'vatNumber' => $vatNumber,
-            'requestDate' => $requestDate,
+            'requestDate' => new \DateTime($requestDate),
             'valid' => $valid,
         ]);
 

--- a/tests/Vies/CheckVatResponseTest.php
+++ b/tests/Vies/CheckVatResponseTest.php
@@ -6,6 +6,11 @@ namespace DragonBe\Test\Vies;
 use DragonBe\Vies\CheckVatResponse;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Class CheckVatResponseTest
+ *
+ * @package DragonBe\Test\Vies
+ */
 class CheckVatResponseTest extends TestCase
 {
     /**
@@ -50,7 +55,25 @@ class CheckVatResponseTest extends TestCase
     }
 
     /**
+     * Test that a VAT response can be created
+     *
      * @dataProvider validationProvider
+     * @covers \DragonBe\Vies\CheckVatResponse::__construct
+     * @covers \DragonBe\Vies\CheckVatResponse::populate
+     * @covers \DragonBe\Vies\CheckVatResponse::setCountryCode
+     * @covers \DragonBe\Vies\CheckVatResponse::getCountryCode
+     * @covers \DragonBe\Vies\CheckVatResponse::setVatNumber
+     * @covers \DragonBe\Vies\CheckVatResponse::getVatNumber
+     * @covers \DragonBe\Vies\CheckVatResponse::setRequestDate
+     * @covers \DragonBe\Vies\CheckVatResponse::getRequestDate
+     * @covers \DragonBe\Vies\CheckVatResponse::setValid
+     * @covers \DragonBe\Vies\CheckVatResponse::isValid
+     * @covers \DragonBe\Vies\CheckVatResponse::setName
+     * @covers \DragonBe\Vies\CheckVatResponse::getName
+     * @covers \DragonBe\Vies\CheckVatResponse::setAddress
+     * @covers \DragonBe\Vies\CheckVatResponse::getAddress
+     * @covers \DragonBe\Vies\CheckVatResponse::setIdentifier
+     * @covers \DragonBe\Vies\CheckVatResponse::getIdentifier
      */
     public function testCanCreateResponseAtConstruct($validCheck)
     {
@@ -67,6 +90,22 @@ class CheckVatResponseTest extends TestCase
 
     /**
      * @dataProvider validationProvider
+     * @covers \DragonBe\Vies\CheckVatResponse::__construct
+     * @covers \DragonBe\Vies\CheckVatResponse::populate
+     * @covers \DragonBe\Vies\CheckVatResponse::setCountryCode
+     * @covers \DragonBe\Vies\CheckVatResponse::getCountryCode
+     * @covers \DragonBe\Vies\CheckVatResponse::setVatNumber
+     * @covers \DragonBe\Vies\CheckVatResponse::getVatNumber
+     * @covers \DragonBe\Vies\CheckVatResponse::setRequestDate
+     * @covers \DragonBe\Vies\CheckVatResponse::getRequestDate
+     * @covers \DragonBe\Vies\CheckVatResponse::setValid
+     * @covers \DragonBe\Vies\CheckVatResponse::isValid
+     * @covers \DragonBe\Vies\CheckVatResponse::setName
+     * @covers \DragonBe\Vies\CheckVatResponse::getName
+     * @covers \DragonBe\Vies\CheckVatResponse::setAddress
+     * @covers \DragonBe\Vies\CheckVatResponse::getAddress
+     * @covers \DragonBe\Vies\CheckVatResponse::setIdentifier
+     * @covers \DragonBe\Vies\CheckVatResponse::getIdentifier
      */
     public function testCanCreateResponseWithoutNameAndAddressAtConstruct($validCheck)
     {
@@ -84,6 +123,22 @@ class CheckVatResponseTest extends TestCase
 
     /**
      * @dataProvider validationProvider
+     * @covers \DragonBe\Vies\CheckVatResponse::__construct
+     * @covers \DragonBe\Vies\CheckVatResponse::populate
+     * @covers \DragonBe\Vies\CheckVatResponse::setCountryCode
+     * @covers \DragonBe\Vies\CheckVatResponse::getCountryCode
+     * @covers \DragonBe\Vies\CheckVatResponse::setVatNumber
+     * @covers \DragonBe\Vies\CheckVatResponse::getVatNumber
+     * @covers \DragonBe\Vies\CheckVatResponse::setRequestDate
+     * @covers \DragonBe\Vies\CheckVatResponse::getRequestDate
+     * @covers \DragonBe\Vies\CheckVatResponse::setValid
+     * @covers \DragonBe\Vies\CheckVatResponse::isValid
+     * @covers \DragonBe\Vies\CheckVatResponse::setName
+     * @covers \DragonBe\Vies\CheckVatResponse::getName
+     * @covers \DragonBe\Vies\CheckVatResponse::setAddress
+     * @covers \DragonBe\Vies\CheckVatResponse::getAddress
+     * @covers \DragonBe\Vies\CheckVatResponse::setIdentifier
+     * @covers \DragonBe\Vies\CheckVatResponse::getIdentifier
      */
     public function testCanCreateResponseWithArrayAtConstruct($validCheck)
     {
@@ -98,10 +153,72 @@ class CheckVatResponseTest extends TestCase
         $this->assertSame($response['requestIdentifier'], $checkVatResponse->getIdentifier());
     }
 
+    /**
+     * @covers \DragonBe\Vies\CheckVatResponse::__construct
+     * @covers \DragonBe\Vies\CheckVatResponse::getRequestDate
+     */
     public function testDefaultDateIsNow()
     {
         $vatResponse = new CheckVatResponse();
         $this->assertInstanceOf('\\DateTime', $vatResponse->getRequestDate());
         $this->assertSame(date('Y-m-dP'), $vatResponse->getRequestDate()->format('Y-m-dP'));
+    }
+
+    /**
+     * @covers \DragonBe\Vies\CheckVatResponse::__construct
+     * @covers \DragonBe\Vies\CheckVatResponse::populate
+     * @expectedException \InvalidArgumentException
+     */
+    public function testExceptionIsThrownWhenRequiredParametersAreMissing()
+    {
+        $vatResponse = new CheckVatResponse([]);
+    }
+
+    public function requiredDataProvider()
+    {
+        return [
+            ['DE', '123456749', date('Y-m-dP'), true],
+            ['ES', '987654321', date('Y-m-dP'), false],
+        ];
+    }
+
+    /**
+     * @dataProvider requiredDataProvider
+     * @covers \DragonBe\Vies\CheckVatResponse::__construct
+     * @covers \DragonBe\Vies\CheckVatResponse::populate
+     * @covers \DragonBe\Vies\CheckVatResponse::setCountryCode
+     * @covers \DragonBe\Vies\CheckVatResponse::getCountryCode
+     * @covers \DragonBe\Vies\CheckVatResponse::setVatNumber
+     * @covers \DragonBe\Vies\CheckVatResponse::getVatNumber
+     * @covers \DragonBe\Vies\CheckVatResponse::setRequestDate
+     * @covers \DragonBe\Vies\CheckVatResponse::getRequestDate
+     * @covers \DragonBe\Vies\CheckVatResponse::setValid
+     * @covers \DragonBe\Vies\CheckVatResponse::isValid
+     * @covers \DragonBe\Vies\CheckVatResponse::setName
+     * @covers \DragonBe\Vies\CheckVatResponse::getName
+     * @covers \DragonBe\Vies\CheckVatResponse::setAddress
+     * @covers \DragonBe\Vies\CheckVatResponse::getAddress
+     * @covers \DragonBe\Vies\CheckVatResponse::setIdentifier
+     * @covers \DragonBe\Vies\CheckVatResponse::getIdentifier
+     */
+    public function testResponseContainsEmptyValuesWithOnlyRequiredArguments($countryCode, $vatNumber, $requestDate, $valid)
+    {
+        $expectedResult = [
+            'countryCode' => $countryCode,
+            'vatNumber' => $vatNumber,
+            'requestDate' => substr($requestDate, 0, -6),
+            'valid' => $valid,
+            'name' => '---',
+            'address' => '---',
+            'identifier' => '',
+        ];
+        $vatResponse = new CheckVatResponse([
+            'countryCode' => $countryCode,
+            'vatNumber' => $vatNumber,
+            'requestDate' => $requestDate,
+            'valid' => $valid,
+        ]);
+
+        $this->assertSame($expectedResult, $vatResponse->toArray());
     }
 }

--- a/tests/Vies/HeartBeatTest.php
+++ b/tests/Vies/HeartBeatTest.php
@@ -1,9 +1,12 @@
 <?php
+declare (strict_types=1);
+
 namespace DragonBe\Test\Vies;
 
 use DragonBe\Vies\HeartBeat;
+use PHPUnit\Framework\TestCase;
 
-class HeartBeatTest extends \PHPUnit_Framework_TestCase
+class HeartBeatTest extends TestCase
 {
     /**
      * @expectedException \DomainException

--- a/tests/Vies/ValidatorTest.php
+++ b/tests/Vies/ValidatorTest.php
@@ -1,10 +1,12 @@
 <?php
+declare (strict_types=1);
 
 namespace DragonBe\Test\Vies;
 
 use DragonBe\Vies\Vies;
+use PHPUnit\Framework\TestCase;
 
-class ValidatorTest extends \PHPUnit_Framework_TestCase
+class ValidatorTest extends TestCase
 {
     public function vatNumberProvider()
     {

--- a/tests/Vies/ValidatorTest.php
+++ b/tests/Vies/ValidatorTest.php
@@ -10,7 +10,7 @@ class ValidatorTest extends TestCase
 {
     public function vatNumberProvider()
     {
-        return array(
+        return [
             'AT' => ['U10223006', ['U1022300', 'A10223006', 'U10223005']],
             'BE' => ['776091951', ['0776091952', '07760919']],
             'BG' => ['301004503', ['10100450', '301004502']],
@@ -45,7 +45,7 @@ class ValidatorTest extends TestCase
             'SE' => ['556188840401', ['556188840400', '1234567890', '556181140401']],
             'SI' => ['15012557', ['15012556', '12345670', '01234567', '1234567']],
             'SK' => ['4030000007', ['4030000006', '123456789', '0123456789', '4060000007']]
-        );
+        ];
     }
 
     public function testVatNumberChecksumSuccess()
@@ -53,7 +53,7 @@ class ValidatorTest extends TestCase
         $vies = new Vies();
 
         foreach ($this->vatNumberProvider() as $country => $numbers) {
-            if (!is_array($numbers[0])) {
+            if (! is_array($numbers[0])) {
                 $numbers[0] = [$numbers[0]];
             }
             foreach ($numbers[0] as $number) {

--- a/tests/Vies/ViesTest.php
+++ b/tests/Vies/ViesTest.php
@@ -11,12 +11,12 @@ class ViestTest extends TestCase
 {
     public function vatNumberProvider()
     {
-        return array (
-            array ('0123456749','0123456749'),
-            array ('0123 456 749','0123456749'),
-            array ('0123.456.749','0123456749'),
-            array ('0123-456-749','0123456749'),
-        );
+        return  [
+             ['0123456749','0123456749'],
+             ['0123 456 749','0123456749'],
+             ['0123.456.749','0123456749'],
+             ['0123-456-749','0123456749'],
+        ];
     }
     /**
      * @dataProvider vatNumberProvider
@@ -28,7 +28,7 @@ class ViestTest extends TestCase
             Vies::filterVat($vatNumber));
     }
 
-    protected function _createdStubbedViesClient($response)
+    protected function createdStubbedViesClient($response)
     {
         $stub = $this->getMockFromWsdl(
             dirname(__FILE__) . '/_files/checkVatService.wsdl');
@@ -55,9 +55,9 @@ class ViestTest extends TestCase
         $response->traderName = '';
         $response->traderAddress = '';
         $response->requestIdentifier = 'XYZ1234567890';
-        
-        $vies = $this->_createdStubbedViesClient($response);
-        
+
+        $vies = $this->createdStubbedViesClient($response);
+
         $response = $vies->validateVat('BE', '0123.456.749');
         $this->assertInstanceOf('\\DragonBe\\Vies\\CheckVatResponse', $response);
         $this->assertTrue($response->isValid());
@@ -79,7 +79,7 @@ class ViestTest extends TestCase
         $response->traderAddress = '';
         $response->requestIdentifier = 'XYZ1234567890';
 
-        $vies = $this->_createdStubbedViesClient($response);
+        $vies = $this->createdStubbedViesClient($response);
 
         $response = $vies->validateVat('BE', '0123.456.749', 'PL', '1234567890');
         $this->assertInstanceOf('\\DragonBe\\Vies\\CheckVatResponse', $response);
@@ -98,8 +98,8 @@ class ViestTest extends TestCase
         $response->vatNumber = '0123.ABC.749';
         $response->requestDate = '1983-06-24+23:59';
         $response->valid = false;
-        
-        $vies = $this->_createdStubbedViesClient($response);
+
+        $vies = $this->createdStubbedViesClient($response);
 
         $response = $vies->validateVat('BE', '0123.ABC.749');
         $this->assertInstanceOf('\\DragonBe\\Vies\\CheckVatResponse', $response);
@@ -229,11 +229,11 @@ class ViestTest extends TestCase
      */
     public function testGettingDefaultSoapClient()
     {
-        if (defined('HHVM_VERSION') && !extension_loaded('soap')) {
+        if (defined('HHVM_VERSION') && ! extension_loaded('soap')) {
             $this->markTestSkipped('SOAP not installed');
         }
         $vies = new Vies();
-        $vies->setSoapClient($this->_createdStubbedViesClient('blabla')->getSoapClient());
+        $vies->setSoapClient($this->createdStubbedViesClient('blabla')->getSoapClient());
         $soapClient = $vies->getSoapClient();
         $expected = '\\SoapClient';
         $this->assertInstanceOf($expected, $soapClient);
@@ -244,7 +244,7 @@ class ViestTest extends TestCase
      */
     public function testDefaultSoapClientIsLazyLoaded()
     {
-        if (defined('HHVM_VERSION') && !extension_loaded('soap')) {
+        if (defined('HHVM_VERSION') && ! extension_loaded('soap')) {
             $this->markTestSkipped('SOAP not installed');
         }
         $wsdl = dirname(__FILE__) . '/_files/checkVatService.wsdl';
@@ -299,14 +299,14 @@ class ViestTest extends TestCase
      */
     public function testSettingSoapOptions()
     {
-        if(defined('HHVM_VERSION')) {
+        if (defined('HHVM_VERSION')) {
             $this->markTestSkipped('This test does not work for HipHop VM');
         }
-        $options = array (
+        $options = [
             'soap_version' => SOAP_1_1,
-        );
+        ];
         $vies = new Vies();
-        $vies->setSoapClient($this->_createdStubbedViesClient('blabla')->getSoapClient());
+        $vies->setSoapClient($this->createdStubbedViesClient('blabla')->getSoapClient());
         $vies->setOptions($options);
         $soapClient = $vies->getSoapClient();
         $actual = $soapClient->_soap_version;

--- a/tests/Vies/ViesTest.php
+++ b/tests/Vies/ViesTest.php
@@ -1,9 +1,13 @@
 <?php
+declare (strict_types=1);
+
 namespace DragonBe\Test\Vies;
 
+use DragonBe\Vies\HeartBeat;
 use DragonBe\Vies\Vies;
+use PHPUnit\Framework\TestCase;
 
-class ViestTest extends \PHPUnit_Framework_TestCase
+class ViestTest extends TestCase
 {
     public function vatNumberProvider()
     {
@@ -180,13 +184,14 @@ class ViestTest extends \PHPUnit_Framework_TestCase
 
     private function createHeartBeatMock($bool)
     {
-        $heartBeatMock = $this->getMock(
-            '\\DragonBe\\Vies\\HeartBeat',
-            array ('isAlive')
-        );
+        $heartBeatMock = $this->getMockBuilder(HeartBeat::class)
+            ->setMethods(['isAlive'])
+            ->getMock();
+
         $heartBeatMock->expects($this->once())
             ->method('isAlive')
             ->will($this->returnValue($bool));
+
         return $heartBeatMock;
     }
 


### PR DESCRIPTION
This is a major upgrade!

We've updated our classes and our tests to make use of all PHP 7.1 features and drop support for [no-longer maintained versions of PHP](https://secure.php.net/supported-versions.php).

This means that the following PHP versions will no longer be supported:
-  5.4
-  5.5
-  5.6
-  hhvm
- 7.0

If you can't update to PHP 7.1 yet, no dispair. We will keep version 1.0 maintained until December 31 2018, the same date for the security support of PHP 5.6.
