### PR TITLE
Adding an example for async processing of VAT ID's

### DIFF
--- a/examples/async_processing/.gitignore
+++ b/examples/async_processing/.gitignore
@@ -1,0 +1,1 @@
+vatqueue.db

--- a/examples/async_processing/README.md
+++ b/examples/async_processing/README.md
@@ -1,0 +1,48 @@
+# Async processing of VAT ID validation
+
+A common question we got is how we deal with VAT ID validation when the official [European Commission (EC) VAT Information Exchange System (VIES)](http://ec.europa.eu/taxation_customs/vies) is down or not operational. Often we explain that we have several tools in place to perform many validations offline like `validateVatSum` and our `getHeartBeat()->isAlive()`, but this doesn't solve the problem for many users.
+
+Therefor I've created this simple Async VAT Validation setup using a `queue.php` for adding VAT ID's into a simple SQLite DB queue and `worker.php` which will run as a daemon constantly checking the queue to see if there's a new VAT ID to validate. This worker also implements the "heart beat" checker which puts it into sleep mode for 30 minutes.
+
+The benefit is you can run the worker as a process and have the queue script listening onto a seperate port to which you can easily send your VAT ID's.
+
+**THIS IS A PROOF-OF-CONCEPT!!! DO NOT USE AS-IS IN PRODUCTION!!!**
+
+## Step 1: Initialise the database
+
+We're making use of SQLite for this PoC, but feel free to set it up for whatever backend you feel comfortable with.
+
+```
+cd examples/async_processing
+sqlite3 vatqueue.db < vatqueue.sql
+```
+
+## Step 2: Starting the worker
+
+This will run the worker as a daemon and puts it in the background. You can also run it in Screen or even in Docker if you want.
+
+```
+php worker.php &
+```
+
+## Step 3: Start the queue listener
+
+We also want a simple interface where we can just point the VAT ID to, and nothing is easier than to use it as a web service. In this case we're using the build-in PHP web server to handle requests, but you can also have it run in Apache, Nginx or even inside a Docker container.
+
+```
+php -S localhost:11984 queue.php
+```
+
+## Step 4: Add VAT ID's to the queue
+
+Assuming that all steps have been followed as described above, you can just throw VAT ID's to the web service endpoint by using curl or ajax calls.
+
+```
+curl "http://localhost:11984/?vatid=BE0811231234"
+curl "http://localhost:11984/?vatid=BE0811231235"
+curl "http://localhost:11984/?vatid=BE0811231236"
+``` 
+
+## Step 5: See the validation
+
+Now you just need to read from the backend to see which VAT ID was valid and which one did not. And as long the `worker.php` is running, it will keep reading the queue until all things are processed.

--- a/examples/async_processing/queue.php
+++ b/examples/async_processing/queue.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DragonBe;
+
+$pdo = new \PDO('sqlite:' . __DIR__ . '/vatqueue.db');
+$isAlreadyValidatedStmt = $pdo->prepare('SELECT `id` FROM `vat_validation` WHERE `vat_id` = ?');
+$addToQueueStmt = $pdo->prepare('INSERT INTO `vat_validation` (`vat_id`) VALUES (?)');
+$updateQueueStmt = $pdo->prepare('UPDATE `vat_validation` SET `validated` = "" WHERE `id` = ?');
+
+if ([] !== $_GET && array_key_exists('vatid', $_GET)) {
+    $vatId = filter_var($_GET['vatid'], FILTER_SANITIZE_SPECIAL_CHARS, FILTER_FLAG_ENCODE_HIGH);
+    $vatId = str_replace(['.', '-', ' ', '_'], '', $vatId);
+
+    $isAlreadyValidatedStmt->bindValue(1, $vatId);
+    $isAlreadyValidatedStmt->execute();
+
+    $result = $isAlreadyValidatedStmt->fetchColumn(0);
+    if (false === $result) {
+        $addToQueueStmt->bindValue(1, $vatId);
+        $addToQueueStmt->execute();
+    } else {
+        $updateQueueStmt->bindValue(1, $result);
+        $updateQueueStmt->execute();
+    }
+    header('Location: ' . $_SERVER['PHP_SELF']);
+}

--- a/examples/async_processing/vatqueue.sql
+++ b/examples/async_processing/vatqueue.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS `vat_validation`;
+CREATE TABLE `vat_validation` (
+    `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, 
+    `vat_id` TEXT NOT NULL, 
+    `validated` TEXT NOT NULL DEFAULT '', 
+    `result` TEXT NOT NULL DEFAULT '', 
+    `reason` TEXT NOT NULL DEFAULT '', 
+    `name` TEXT NOT NULL DEFAULT '', 
+    `address` TEXT NOT NULL DEFAULT '', 
+    `identifier` TEXT NOT NULL DEFAULT ''
+);

--- a/examples/async_processing/worker.php
+++ b/examples/async_processing/worker.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace DragonBe;
+
+use DragonBe\Vies\Vies;
+use DragonBe\Vies\ViesException;
+use DragonBe\Vies\ViesServiceException;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+$pdo = new \PDO('sqlite:' . __DIR__ . '/vatqueue.db');
+$validationStmt = $pdo->prepare('SELECT `id`, `vat_id` FROM `vat_validation` WHERE `validated` = "" ORDER BY `id` DESC LIMIT 1');
+$updateVatId = $pdo->prepare('UPDATE `vat_validation` SET `validated` = ?, `result` = ?, `reason` = ?, `name` = ?, `address` = ?, `identifier` = ? WHERE `id` = ?');
+
+function debug($message = '')
+{
+    $debug = false;
+    if ($debug) {
+        echo '[DEBUG] >>> ' . $message . PHP_EOL;
+    }
+}
+
+$vies = new Vies();
+do {
+    if (!$vies->getHeartBeat()->isAlive()) {
+        debug('Service is down, sleeping for 30 minutes');
+        sleep(1800); // sleep for 30 minutes
+        continue;
+    }
+    $validationStmt->execute();
+
+    $row = $validationStmt->fetch(\PDO::FETCH_ASSOC);
+    if (false === $row) {
+        debug('No new data found');
+        sleep(60);
+        continue;
+    }
+    $id = (int) $row['id'];
+    $vatin = $row['vat_id'];
+    $vatCountry = substr($vatin, 0, 2);
+    $vatNumber = substr($vatin, 2);
+    $vatNumber = $vies->filterVat($vatNumber);
+    $reason = '';
+    
+    try {
+        $result = $vies->validateVat($vatCountry, $vatNumber);
+        debug('Result: ' . var_export($result, 1));
+    } catch (ViesServiceException $viesServiceException) {
+        // Connection was broken or other weird things went on, let's wait a few
+        debug('ViesServiceException: ' . $viesServiceException->getMessage());
+        sleep(60);
+        continue;
+    } catch (ViesException $viesException) {
+        // Something went wrong with the validation, add to log and notify service operators
+        debug('ViesException: ' . $viesException->getMessage());
+        $reason = $viesException->getMessage();
+    }
+
+    $updateVatId->bindValue(1, $result->getRequestDate()->format('Y-m-d H:i:s O'));
+    $updateVatId->bindValue(2, $result->isValid() ? 'valid' : 'invalid');
+    $updateVatId->bindValue(3, $reason);
+    $updateVatId->bindValue(4, $result->getName());
+    $updateVatId->bindValue(5, $result->getAddress());
+    $updateVatId->bindValue(6, $result->getIdentifier());
+    $updateVatId->bindValue(7, $id);
+
+    $updateVatId->execute();
+  
+} while (true);


### PR DESCRIPTION
This is a simple, but very effective way to process VAT ID's asynchronously in a safe manner. Please see the README for more details.