### PR TITLE
Remove duplicate composer self-update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 7.3
 
 before_script:
-  - composer self-update
   - composer install --prefer-source --no-interaction
 
 script:


### PR DESCRIPTION
Travis does a `composer self-update` by default, for example:
* https://travis-ci.org/DragonBe/vies/jobs/479030486#L485
* https://travis-ci.org/DragonBe/vies/jobs/479030486#L498
