### PR TITLE
Bug 67: Adding type checking for numeric VAT ID's

### DIFF
--- a/src/Vies/Validator/ValidatorHR.php
+++ b/src/Vies/Validator/ValidatorHR.php
@@ -27,7 +27,7 @@ class ValidatorHR extends ValidatorAbstract
             return false;
         }
 
-        if (!ctype_digit($vatNumber)) {
+        if (! ctype_digit($vatNumber)) {
             return false;
         }
 

--- a/src/Vies/Validator/ValidatorHR.php
+++ b/src/Vies/Validator/ValidatorHR.php
@@ -27,6 +27,10 @@ class ValidatorHR extends ValidatorAbstract
             return false;
         }
 
+        if (!ctype_digit($vatNumber)) {
+            return false;
+        }
+
         $product = 10;
 
         for ($i = 0; $i < 10; $i++) {

--- a/src/Vies/Validator/ValidatorIT.php
+++ b/src/Vies/Validator/ValidatorIT.php
@@ -40,6 +40,10 @@ class ValidatorIT extends ValidatorAbstract
             return false;
         }
 
+        if (!ctype_digit($vatNumber)) {
+            return false;
+        }
+
         if (substr($vatNumber, 0, 7) == '0000000') {
             return false;
         }

--- a/src/Vies/Validator/ValidatorIT.php
+++ b/src/Vies/Validator/ValidatorIT.php
@@ -40,7 +40,7 @@ class ValidatorIT extends ValidatorAbstract
             return false;
         }
 
-        if (!ctype_digit($vatNumber)) {
+        if (! ctype_digit($vatNumber)) {
             return false;
         }
 

--- a/tests/Vies/Validator/ValidatorHRTest.php
+++ b/tests/Vies/Validator/ValidatorHRTest.php
@@ -21,6 +21,7 @@ class ValidatorHRTest extends AbstractValidatorTest
             ['38192148118', true],
             ['3819214811', false],
             ['1234567890A', false],
+            ['AA123456789', false],
         ];
     }
 }

--- a/tests/Vies/Validator/ValidatorITTest.php
+++ b/tests/Vies/Validator/ValidatorITTest.php
@@ -22,6 +22,7 @@ class ValidatorITTest extends AbstractValidatorTest
             ['00000010214', false],
             ['1234567890', false],
             ['00000001234', false],
+            ['AA123456789', false],
         ];
     }
 }


### PR DESCRIPTION
Fixing bug #67 reported by @willemstuursma regarding validating numeric only VAT ID's with non-numeric values.