### PR TITLE
Implement `{validator}::sanitize`

### DIFF
--- a/src/Vies/Validator/ValidatorAbstract.php
+++ b/src/Vies/Validator/ValidatorAbstract.php
@@ -13,6 +13,15 @@ abstract class ValidatorAbstract implements ValidatorInterface
     abstract public function validate(string $vatNumber): bool;
 
     /**
+     * {@inheritdoc}
+     */
+    public static function sanitize(string $vatNumber): string
+    {
+        // Filter VAT number and normalizes it to an alfanumeric string
+        return str_replace([' ', '.', '-'], '', $vatNumber);
+    }
+
+    /**
      * @param int $val
      *
      * @return int

--- a/src/Vies/Validator/ValidatorBE.php
+++ b/src/Vies/Validator/ValidatorBE.php
@@ -31,6 +31,20 @@ class ValidatorBE extends ValidatorAbstract
     /**
      * {@inheritdoc}
      */
+    public static function sanitize(string $vatNumber): string
+    {
+        $vatNumber = parent::sanitize($vatNumber);
+
+        if (strlen($vatNumber) === 9) {
+            $vatNumber = "0" . $vatNumber;
+        }
+
+        return $vatNumber;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function validate(string $vatNumber): bool
     {
         if (strlen($vatNumber) == 9) {

--- a/src/Vies/Validator/ValidatorBE.php
+++ b/src/Vies/Validator/ValidatorBE.php
@@ -47,11 +47,13 @@ class ValidatorBE extends ValidatorAbstract
      */
     public function validate(string $vatNumber): bool
     {
-        if (strlen($vatNumber) == 9) {
-            $vatNumber = "0" . $vatNumber;
-        }
+        # DISABLED - use ::sanitize to prepare the $vatNumber
+        ## todo delete this commented code
+        #if (strlen($vatNumber) == 9) {
+        #    $vatNumber = "0" . $vatNumber;
+        #}
 
-        if (strlen($vatNumber) != 10) {
+        if (strlen($vatNumber) !== 10) {
             return false;
         }
 

--- a/src/Vies/Validator/ValidatorInterface.php
+++ b/src/Vies/Validator/ValidatorInterface.php
@@ -14,6 +14,15 @@ namespace DragonBe\Vies\Validator;
 interface ValidatorInterface
 {
     /**
+     * Prepares the given VAT number for the validation.
+     *
+     * @param string $vatNumber
+     *
+     * @return string
+     */
+    public static function sanitize(string $vatNumber): string;
+
+    /**
      * @param string $vatNumber
      *
      * @return bool


### PR DESCRIPTION
- ValidatorInterface new method `::sanitize`
- ValidatorAbstract new static method `::sanitize`

- `Vies::filterVat` "moved" to `ValidatorAbstract::sanitize` (default sanitization(?))
- `ValidatorBE::sanitize` calls `parent::sanitize` FIRST (clean up) and then adds missing leading zero.)
Note: keeping `Vies::filterVat` because it was public and some users may rely on it. But it now redirects to `ValidatorAbstract::sanitize`.
- `Vies::validateVatSum` now updating the `$vatNumber` by reference.
- `Vies::validateVatSum` calls `$validator` `::sanitize` and then `::validate`.

Note: added notes like `#DISABLED - ...` and `## todo ...` which should be deleted before release.