### PR TITLE
Fix #76: Removal of auto-prepending of 0 in BE VAT

### DIFF
--- a/src/Vies/Validator/ValidatorBE.php
+++ b/src/Vies/Validator/ValidatorBE.php
@@ -33,10 +33,6 @@ class ValidatorBE extends ValidatorAbstract
      */
     public function validate(string $vatNumber): bool
     {
-        if (strlen($vatNumber) == 9) {
-            $vatNumber = "0" . $vatNumber;
-        }
-
         if (strlen($vatNumber) != 10) {
             return false;
         }

--- a/tests/Vies/Validator/ValidatorBETest.php
+++ b/tests/Vies/Validator/ValidatorBETest.php
@@ -18,9 +18,11 @@ class ValidatorBETest extends AbstractValidatorTest
     public function vatNumberProvider()
     {
         return [
-            ['776091951', true],
+            ['776091951', false],
             ['0776091952', false],
             ['07760919', false],
+            ['0417710407', true],
+            ['0627515170', true],
         ];
     }
 }

--- a/tests/Vies/ValidatorTest.php
+++ b/tests/Vies/ValidatorTest.php
@@ -12,7 +12,7 @@ class ValidatorTest extends TestCase
     {
         return [
             'AT' => ['U10223006', ['U1022300', 'A10223006', 'U10223005']],
-            'BE' => ['776091951', ['0776091952', '07760919']],
+            'BE' => ['0776091951', ['0776091952', '07760919']],
             'BG' => [['204514061', '301004503'], ['10100450', '301004502']],
             'CY' => ['00532445O', ['005324451', '0053244511', '12000139V', '72000139V']],
             'CZ' => [
@@ -64,7 +64,8 @@ class ValidatorTest extends TestCase
             }
             foreach ($numbers[0] as $number) {
                 $result = $vies->validateVatSum($country, $number);
-                $this->assertTrue($result);
+                $this->assertTrue($result,
+                    'VAT ID ' . $country . $number . ' should validate, but is not valid');
             }
         }
     }

--- a/tests/Vies/ValidatorTest.php
+++ b/tests/Vies/ValidatorTest.php
@@ -64,8 +64,10 @@ class ValidatorTest extends TestCase
             }
             foreach ($numbers[0] as $number) {
                 $result = $vies->validateVatSum($country, $number);
-                $this->assertTrue($result,
-                    'VAT ID ' . $country . $number . ' should validate, but is not valid');
+                $this->assertTrue(
+                    $result,
+                    'VAT ID ' . $country . $number . ' should validate, but is not valid'
+                );
             }
         }
     }


### PR DESCRIPTION
Issue #76 started the discussion to assist users for bad input by prepending a 0 for Belgian VAT IDs, but since the goal of this library is to validate the correctness of input and the regulation clearly states that Belgian VAT ID's have 10 digits, starting with a "0" we should adhere to the regulation and reject VAT IDs that are still using the older 9-digit VAT IDs without the leading 0.

Since I consider this a bug in the library, I will mark it as such.