### PR TITLE
Adding coverage reporting for SonarCloud

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -26,4 +26,5 @@ sonar.tests=tests
 # Properties specific to language plugins:
 sonar.java.checkstyle.reportPaths=build/logs/checkstyle.xml
 sonar.php.coverage.reportPath=build/logs/coverage/coverage-xml/index.xml
+sonar.php.coverage.reportPaths=build/logs/clover.xml
 sonar.php.tests.reportPath=build/logs/junit.xml


### PR DESCRIPTION
Implementing code coverage reporting as described in the documentation for SonarCloud on https://sonarcloud.io/documentation/analysis/coverage/