### PR TITLE
Allow MOSS-registered non-EU companies to be used as requester

### DIFF
--- a/src/Vies/Vies.php
+++ b/src/Vies/Vies.php
@@ -272,7 +272,7 @@ class Vies
         $this->addOptionalArguments($requestParams, 'traderCity', $traderCity);
 
         if ($requesterCountryCode && $requesterVatNumber) {
-            if (! isset(self::VIES_EU_COUNTRY_LIST[$requesterCountryCode])) {
+            if (! isset(self::VIES_EU_COUNTRY_LIST[$requesterCountryCode]) && 'EU' !== $requesterCountryCode) {
                 throw new ViesException(sprintf('Invalid requestor country code "%s" provided', $requesterCountryCode));
             }
             $requesterVatNumber = self::filterVat($requesterVatNumber);


### PR DESCRIPTION
Kinda amazed this hasn't come up yet, I guess the compliance levels aren't as high as they should be :D

Anyway, non EU companies registering for MOSS get a EUxxxxx VAT number, so we need to be able to put that in the requester VAT ID. For reference, http://ec.europa.eu/taxation_customs/vies/ allows you to input "EU-MOSS Number" in the requester member state.