### PR TITLE
Issue #91: Adding PHP 7.4 testing in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
 - 7.1
 - 7.2
 - 7.3
+- 7.4
 addons:
   sonarcloud:
     organization: "dragonbe-github" # the key of the org you chose at step #3


### PR DESCRIPTION
With the new PHP 7.4 release we want to test against this version in CI as well.