### PR TITLE
for vat numbers from FI, allow 0 as last digit

### DIFF
--- a/src/Vies/Validator/ValidatorFI.php
+++ b/src/Vies/Validator/ValidatorFI.php
@@ -41,6 +41,8 @@ class ValidatorFI extends ValidatorAbstract
         $weights = [7, 9, 10, 5, 8, 4, 2];
         $checkval = $this->sumWeights($weights, $vatNumber);
 
-        return 11 - ($checkval % 11) == (int) $vatNumber[7];
+        return (0 === $checkval % 11)
+            ? (int) $vatNumber[7] === 0
+            : 11 - ($checkval % 11) == (int) $vatNumber[7];
     }
 }

--- a/tests/Vies/Validator/ValidatorFITest.php
+++ b/tests/Vies/Validator/ValidatorFITest.php
@@ -21,6 +21,7 @@ class ValidatorFITest extends AbstractValidatorTest
             ['09853608', true],
             ['09853607', false],
             ['1234567', false],
+            ['01089940', true],
         ];
     }
 }


### PR DESCRIPTION
This is a mitigation for #95 
For FI VAT numbers, implementation of this algorithm

> 
> VAT format: [C1 C2 C3 C4 C5 C6 C7 C8]
>  
> Range:
>       C2 .. C8 Numeric from 0 to 9
> 
> Rules:
>  C8
>       R = 11 - (7*C1 + 9*C2 + 10*C3 + 5*C4 + 8*C5 + 4*C6 + 2*C7) modulo11
>       If R = 10 then, VAT number is invalid
>       If R = 11 then C8 = 0
>       Else C8 = R

lacks acceptance for 
> if R = 11 then C8 = 0

This PR adds that case as valid VAT