### PR TITLE
Issue #99: Problems validating non-Latin trader values

### DIFF
--- a/src/Vies/Vies.php
+++ b/src/Vies/Vies.php
@@ -386,7 +386,7 @@ class Vies
     private function filterArgument(string $argumentValue): string
     {
         $argumentValue = str_replace(['"', '\''], '', $argumentValue);
-        return filter_var($argumentValue, FILTER_SANITIZE_SPECIAL_CHARS, FILTER_FLAG_STRIP_LOW);
+        return filter_var($argumentValue, FILTER_SANITIZE_STRIPPED, FILTER_FLAG_STRIP_LOW);
     }
 
     /**
@@ -398,8 +398,9 @@ class Vies
      */
     private function validateArgument(string $argumentValue): bool
     {
+        $regexp = '/^[a-zA-Z0-9\s\.\-,&\+\(\)\pL]+$/u';
         if (false === filter_var($argumentValue, FILTER_VALIDATE_REGEXP, [
-            'options' => ['regexp' => '/^[a-zA-Z0-9\s\.\-,\pL]+$/u']
+            'options' => ['regexp' => $regexp]
         ])) {
             return false;
         }

--- a/src/Vies/Vies.php
+++ b/src/Vies/Vies.php
@@ -386,7 +386,7 @@ class Vies
     private function filterArgument(string $argumentValue): string
     {
         $argumentValue = str_replace(['"', '\''], '', $argumentValue);
-        return filter_var($argumentValue, FILTER_SANITIZE_SPECIAL_CHARS, FILTER_FLAG_STRIP_HIGH);
+        return filter_var($argumentValue, FILTER_SANITIZE_SPECIAL_CHARS, FILTER_FLAG_STRIP_LOW);
     }
 
     /**
@@ -399,7 +399,7 @@ class Vies
     private function validateArgument(string $argumentValue): bool
     {
         if (false === filter_var($argumentValue, FILTER_VALIDATE_REGEXP, [
-            'options' => ['regexp' => '/^[a-zA-Z0-9\s\.\-,]+$/']
+            'options' => ['regexp' => '/^[a-zA-Z0-9\s\.\-,\pL]+$/u']
         ])) {
             return false;
         }

--- a/src/Vies/Vies.php
+++ b/src/Vies/Vies.php
@@ -398,7 +398,7 @@ class Vies
      */
     private function validateArgument(string $argumentValue): bool
     {
-        $regexp = '/^[a-zA-Z0-9\s\.\-,&\+\(\)\pL]+$/u';
+        $regexp = '/^[a-zA-Z0-9\s\.\-,&\+\(\)\/º\pL]+$/u';
         if (false === filter_var($argumentValue, FILTER_VALIDATE_REGEXP, [
             'options' => ['regexp' => $regexp]
         ])) {

--- a/tests/Vies/ValidatorTest.php
+++ b/tests/Vies/ValidatorTest.php
@@ -141,6 +141,58 @@ class ValidatorTest extends TestCase
                     'traderCity'           => 'WARSZAWA',
                 ],
             ],
+            'Ampesant Trader Name' => [
+                [
+                    'countryCode'          => 'BE',
+                    'vatNumber'            => '0458591947',
+                    'requesterCountryCode' => 'BE',
+                    'requesterVatNumber'   => '0458591947',
+                    'traderName'           => 'VAN AERDE & PARTNERS',
+                    'traderCompanyType'    => 'BVBA',
+                    'traderStreet'         => 'RIJSELSTRAAT 274',
+                    'traderPostcode'       => '8200',
+                    'traderCity'           => 'BRUGGE',
+                ],
+            ],
+            'Dot-dash Trader Name' => [
+                [
+                    'countryCode'          => 'BE',
+                    'vatNumber'            => '0467609086',
+                    'requesterCountryCode' => 'BE',
+                    'requesterVatNumber'   => '0467609086',
+                    'traderName'           => 'HAELTERMAN C.V.-KLIMA',
+                    'traderCompanyType'    => 'BVBA',
+                    'traderStreet'         => 'GERAARDSBERGSESTEENWEG 307',
+                    'traderPostcode'       => '9404',
+                    'traderCity'           => 'NINOVE',
+                ],
+            ],
+            'Accent Trader Name' => [
+                [
+                    'countryCode'          => 'BE',
+                    'vatNumber'            => '0873284862',
+                    'requesterCountryCode' => 'BE',
+                    'requesterVatNumber'   => '0873284862',
+                    'traderName'           => '\'t GERIEF',
+                    'traderCompanyType'    => 'CVBA',
+                    'traderStreet'         => 'LICHTAARTSEWEG(HRT) 22',
+                    'traderPostcode'       => '2200',
+                    'traderCity'           => 'HERENTALS',
+                ],
+            ],
+            'Plus Trader Name' => [
+                [
+                    'countryCode'          => 'BE',
+                    'vatNumber'            => '0629758840',
+                    'requesterCountryCode' => 'BE',
+                    'requesterVatNumber'   => '0629758840',
+                    'traderName'           => 'ARCHITECTUUR+',
+                    'traderCompanyType'    => 'BVBA',
+                    'traderStreet'         => 'STATIONSSTRAAT 28',
+                    'traderPostcode'       => '3930',
+                    'traderCity'           => 'HAMONT-ACHEL',
+                ],
+            ],
         ];
     }
 

--- a/tests/Vies/ValidatorTest.php
+++ b/tests/Vies/ValidatorTest.php
@@ -85,4 +85,88 @@ class ValidatorTest extends TestCase
             }
         }
     }
+
+    public function traderDataProvider()
+    {
+        return [
+            'Belgian Trader Name' => [
+                [
+                    'countryCode'          => 'BE',
+                    'vatNumber'            => '0203430576',
+                    'requesterCountryCode' => 'BE',
+                    'requesterVatNumber'   => '0203430576',
+                    'traderName'           => 'B-Rail',
+                    'traderCompanyType'    => 'NV',
+                    'traderStreet'         => 'Frankrijkstraat 65',
+                    'traderPostcode'       => '1060',
+                    'traderCity'           => 'Sint-Gillis',
+                ],
+            ],
+            'German Trader Name' => [
+                [
+                    'countryCode'          => 'DE',
+                    'vatNumber'            => '811569869',
+                    'requesterCountryCode' => 'DE',
+                    'requesterVatNumber'   => '811569869',
+                    'traderName'           => 'Deutsche Bahn',
+                    'traderCompanyType'    => 'AG',
+                    'traderStreet'         => 'Potsdamer Platz 2',
+                    'traderPostcode'       => '10785',
+                    'traderCity'           => 'Berlin',
+                ],
+            ],
+            'Greek Trader Name' => [
+                [
+                    'countryCode'          => 'EL',
+                    'vatNumber'            => '999645865',
+                    'requesterCountryCode' => 'EL',
+                    'requesterVatNumber'   => '999645865',
+                    'traderName'           => 'ΤΡΑΙΝΟΣΕ',
+                    'traderCompanyType'    => 'AE',
+                    'traderStreet'         => 'ΚΑΡΟΛΟΥ 1-3',
+                    'traderPostcode'       => '10437',
+                    'traderCity'           => 'ΑΘΗΝΑ',
+                ],
+            ],
+            'Polish Trader Name' => [
+                [
+                    'countryCode'          => 'PL',
+                    'vatNumber'            => '1132316427',
+                    'requesterCountryCode' => 'PL',
+                    'requesterVatNumber'   => '1132316427',
+                    'traderName'           => 'PKP POLSKIE LINIE KOLEJOWE SPÓŁKA AKCYJNA',
+                    'traderCompanyType'    => '',
+                    'traderStreet'         => 'TARGOWA 74',
+                    'traderPostcode'       => '03-734',
+                    'traderCity'           => 'WARSZAWA',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Testing that arguments that contain non-latin values are still
+     * validated correctly
+     *
+     * @group issue-99
+     * @covers \DragonBe\Vies\Vies::validateVat
+     * @covers \DragonBe\Vies\Vies::validateArgument
+     * @dataProvider TraderDataProvider
+     */
+    public function testArgumentValidationSucceedsForNonLatinArgumentValues(array $traderData)
+    {
+        $vies = new Vies();
+        $vatResponse = $vies->validateVat(
+            $traderData['countryCode'],
+            $traderData['vatNumber'],
+            $traderData['requesterCountryCode'],
+            $traderData['requesterVatNumber'],
+            $traderData['traderName'],
+            $traderData['traderCompanyType'],
+            $traderData['traderStreet'],
+            $traderData['traderPostcode'],
+            $traderData['traderCity']
+        );
+        $this->assertTrue($vatResponse->isValid());
+    }
 }

--- a/tests/Vies/ViesTest.php
+++ b/tests/Vies/ViesTest.php
@@ -449,14 +449,6 @@ class ViesTest extends TestCase
                 'HackThePlanet',
                 'Ltd',
                 'Main Street 1',
-                '1000<?php echo url_decode("%3c%73%63%72%69%70%74%3e%61%6c%65%72%74%28%22%78'
-                . '%73%73%22%29%3b%3c%2f%73%63%72%69%70%74%3e") ?>',
-                'Some Town',
-            ],
-            [
-                'HackThePlanet',
-                'Ltd',
-                'Main Street 1',
                 '1000',
                 '<s c r i p t>alert("xss");</s c r i p t>',
             ],


### PR DESCRIPTION
PR for issue #99: In this commit I changed the way we're filtering and validating characters so that we allow non-Latin characters as we have in Germany, Poland, Greece and other countries.