### PR TITLE
Enhance Dockerfile about building XDebug

### DIFF
--- a/.docker/php7.1/Dockerfile
+++ b/.docker/php7.1/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     unzip \
     zlib1g-dev
 
-RUN curl -sSLo xdebug-latest.tar.gz https://xdebug.org/files/xdebug-2.7.0beta1.tgz \
+RUN curl -sSLo xdebug-latest.tar.gz https://xdebug.org/files/xdebug-2.9.4.tgz \
   && mkdir -p /tmp/xdebug \
   && tar --strip-components=1 -C /tmp/xdebug -xf xdebug-latest.tar.gz \
   && rm xdebug-latest.tar.gz \
@@ -26,7 +26,7 @@ RUN curl -sSLo xdebug-latest.tar.gz https://xdebug.org/files/xdebug-2.7.0beta1.t
 RUN docker-php-ext-install -j$(nproc) \
     soap \
     pcntl \
-    zip 
+    zip
 
 RUN useradd -m -s /bin/bash phpuser \
   && mkdir -p /usr/src/php \

--- a/.docker/php7.2/Dockerfile
+++ b/.docker/php7.2/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     unzip \
     zlib1g-dev
 
-RUN curl -sSLo xdebug-latest.tar.gz https://xdebug.org/files/xdebug-2.7.0beta1.tgz \
+RUN curl -sSLo xdebug-latest.tar.gz https://xdebug.org/files/xdebug-2.9.4.tgz \
   && mkdir -p /tmp/xdebug \
   && tar --strip-components=1 -C /tmp/xdebug -xf xdebug-latest.tar.gz \
   && rm xdebug-latest.tar.gz \
@@ -26,7 +26,7 @@ RUN curl -sSLo xdebug-latest.tar.gz https://xdebug.org/files/xdebug-2.7.0beta1.t
 RUN docker-php-ext-install -j$(nproc) \
     soap \
     pcntl \
-    zip 
+    zip
 
 RUN useradd -m -s /bin/bash phpuser \
   && mkdir -p /usr/src/php \

--- a/.docker/php7.3/Dockerfile
+++ b/.docker/php7.3/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     unzip \
     zlib1g-dev
 
-RUN curl -sSLo xdebug-latest.tar.gz https://xdebug.org/files/xdebug-2.7.0beta1.tgz \
+RUN curl -sSLo xdebug-latest.tar.gz https://xdebug.org/files/xdebug-2.9.4.tgz \
   && mkdir -p /tmp/xdebug \
   && tar --strip-components=1 -C /tmp/xdebug -xf xdebug-latest.tar.gz \
   && rm xdebug-latest.tar.gz \

--- a/.docker/php7.4/Dockerfile
+++ b/.docker/php7.4/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     unzip \
     zlib1g-dev
 
-RUN curl -sSLo xdebug-latest.tar.gz https://xdebug.org/files/xdebug-2.7.0beta1.tgz \
+RUN curl -sSLo xdebug-latest.tar.gz https://xdebug.org/files/xdebug-2.9.4.tgz \
   && mkdir -p /tmp/xdebug \
   && tar --strip-components=1 -C /tmp/xdebug -xf xdebug-latest.tar.gz \
   && rm xdebug-latest.tar.gz \


### PR DESCRIPTION
# Changed log
- Since the stable `XDebug` version has been released.
And it should be great for all `php-7.1` to `php-7.4` versions to use `2.9.4` version instead.