### PR TITLE
Cli client

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ When you have implemented this service package in your own project, be sure that
 ## Requirements
 
 - Minimum PHP version: 7.1
-- Recommended PHP version: 7.2
+- Recommended PHP version: 7.4
 - Extension: soap
 - Extension: pcntl
 - Extension: ctype

--- a/bin/vatcheck
+++ b/bin/vatcheck
@@ -1,0 +1,41 @@
+#!/usr/bin/env php
+<?php
+use DragonBe\Vies\Vies;
+use DragonBe\Vies\ViesException;
+use DragonBe\Vies\ViesServiceException;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (2 !== $argc) {
+    echo 'Usage: ' . $argv[0] . ' <VATID>' . PHP_EOL;
+    exit(0);
+}
+
+$vies = new Vies();
+if (false === $vies->getHeartBeat()->isAlive()) {
+    echo 'EU VIES Service not available at this moment, please try again later' . PHP_EOL;
+    exit(0);
+}
+
+$vatId = splitVatId($argv[1]);
+
+$result = null;
+try {
+    $result = $vies->validateVat($vatId['country'], $vatId['id']);
+} catch (ViesServiceException $vse) {
+    echo $vse->getMessage() . PHP_EOL;
+    exit(1);
+} catch (ViesException $ve) {
+    echo $ve->getMessage() . PHP_EOL;
+    exit(1);
+}
+
+var_dump($result);
+
+function splitVatId(string $vatId): array
+{
+    return [
+        'country' => substr($vatId, 0, 2),
+        'id' => substr($vatId, 2),
+    ];
+}

--- a/bin/vatcheck
+++ b/bin/vatcheck
@@ -17,7 +17,7 @@ if (false === $vies->getHeartBeat()->isAlive()) {
     exit(0);
 }
 
-$vatId = splitVatId($argv[1]);
+$vatId = $vies->splitVatId($argv[1]);
 
 $result = null;
 try {
@@ -30,12 +30,9 @@ try {
     exit(1);
 }
 
-var_dump($result);
-
-function splitVatId(string $vatId): array
-{
-    return [
-        'country' => substr($vatId, 0, 2),
-        'id' => substr($vatId, 2),
-    ];
-}
+echo sprintf(
+        'VAT ID %s %s is %s',
+        $result->getCountryCode(),
+        $result->getVatNumber(),
+        $result->isValid() ? 'VALID' : 'NOT VALID'
+    ) . PHP_EOL;

--- a/bin/vatcheck
+++ b/bin/vatcheck
@@ -8,13 +8,13 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 if (2 !== $argc) {
     echo 'Usage: ' . $argv[0] . ' <VATID>' . PHP_EOL;
-    exit(0);
+    exit(1);
 }
 
 $vies = new Vies();
 if (false === $vies->getHeartBeat()->isAlive()) {
     echo 'EU VIES Service not available at this moment, please try again later' . PHP_EOL;
-    exit(0);
+    exit(2);
 }
 
 $vatId = $vies->splitVatId($argv[1]);
@@ -24,10 +24,10 @@ try {
     $result = $vies->validateVat($vatId['country'], $vatId['id']);
 } catch (ViesServiceException $vse) {
     echo $vse->getMessage() . PHP_EOL;
-    exit(1);
+    exit(3);
 } catch (ViesException $ve) {
     echo $ve->getMessage() . PHP_EOL;
-    exit(1);
+    exit(4);
 }
 
 echo sprintf(

--- a/src/Vies/Vies.php
+++ b/src/Vies/Vies.php
@@ -336,6 +336,20 @@ class Vies
     }
 
     /**
+     * Splits a VAT ID on country code and VAT number
+     *
+     * @param string $vatId
+     * @return array
+     */
+    public function splitVatId(string $vatId): array
+    {
+        return [
+            'country' => substr($vatId, 0, 2),
+            'id' => substr($vatId, 2),
+        ];
+    }
+
+    /**
      * A list of European Union countries as of January 2015
      *
      * @return array

--- a/tests/Vies/ViesTest.php
+++ b/tests/Vies/ViesTest.php
@@ -705,7 +705,7 @@ class ViesTest extends TestCase
         $countryCode = 'BE';
         $vatNumber = '1234567890';
         $resultSet = (new Vies())->splitVatId($vatId);
-        $this->assertSame($resultSet['country'], $countryCode);
-        $this->assertSame($resultSet['id'], $vatNumber);
+        $this->assertSame($countryCode, $resultSet['country']);
+        $this->assertSame($vatNumber, $resultSet['id']);
     }
 }

--- a/tests/Vies/ViesTest.php
+++ b/tests/Vies/ViesTest.php
@@ -644,4 +644,20 @@ class ViesTest extends TestCase
 
         $this->assertInstanceOf(SoapClient::class, $vies->getSoapClient());
     }
+
+    /**
+     * Testing to see if we can split a combined
+     * VAT ID into country code and VAT number.
+     *
+     * @covers ::splitVatId
+     */
+    public function testSplitVatId()
+    {
+        $vatId = 'BE1234567890';
+        $countryCode = 'BE';
+        $vatNumber = '1234567890';
+        $resultSet = (new Vies())->splitVatId($vatId);
+        $this->assertSame($resultSet['country'], $countryCode);
+        $this->assertSame($resultSet['id'], $vatNumber);
+    }
 }


### PR DESCRIPTION
Feature: adding a command-line checker

I needed to quickly check a certain VAT ID, but I didn't want to set up everything I just created this convenient command line checker that will take a VAT ID string (country code and number), perform an offline validation and then check it against the VIES SOAP service.