### PR TITLE
Add ext-pcntl extension requirement check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
     "require": {
         "php": ">=7.1",
         "ext-soap": "*",
-        "ext-ctype": "*"
+        "ext-ctype": "*",
+        "ext-pcntl": "*"
     },
     "require-dev": {
-        "ext-pcntl": "*",
         "phpunit/phpunit": "^7.1",
         "phpunit/php-invoker": "^2.0",
         "phploc/phploc": "^4.0",


### PR DESCRIPTION
# Changed log
- According to the [pcntl extension introduction reference](https://www.php.net/manual/en/intro.pcntl.php), the `pcntl` extension should be checked during `composer install` command executing.
This extension is available for Unix-like operating system.