### PR TITLE
Vies could have an allow test codes flag

### DIFF
--- a/src/Vies/Vies.php
+++ b/src/Vies/Vies.php
@@ -51,7 +51,7 @@ class Vies
     const VIES_WSDL = '/taxation_customs/vies/checkVatService.wsdl';
     const VIES_TEST_WSDL = '/taxation_customs/vies/checkVatTestService.wsdl';
     const VIES_EU_COUNTRY_TOTAL = 28;
-    const VIES_TEST_VAT_NRS = [100, 200];
+    const VIES_TEST_VAT_NRS = [100, 200, 201, 202, 300, 301, 302, 400, 401, 500, 501, 600, 601];
 
     protected const VIES_EU_COUNTRY_LIST = [
         'AT' => ['name' => 'Austria', 'validator' => Validator\ValidatorAT::class],
@@ -86,6 +86,11 @@ class Vies
     ];
 
     /**
+     * @var bool Require explicit checking against self::VIES_TEST_VAT_NRS
+     */
+    protected $allowTestCodes = false;
+
+    /**
      * @var SoapClient
      */
     protected $soapClient;
@@ -104,6 +109,42 @@ class Vies
      * @var HeartBeat A heartbeat checker to verify if the VIES service is available
      */
     protected $heartBeat;
+
+
+    /**
+     * Allow VAT number to be compared to the know VIES test codes (self::VIES_TEST_VAT_NRS)
+     *
+     * @return self
+     */
+    public function allowTestCodes(): self
+    {
+        $this->allowTestCodes = true;
+
+        return $this;
+    }
+
+    /**
+     * Disallow VAT number to be compared to the know VIES test codes (self::VIES_TEST_VAT_NRS)
+     *
+     * @return self
+     */
+    public function disallowTestCodes(): self
+    {
+        $this->allowTestCodes = false;
+
+        return $this;
+    }
+
+    /**
+     * Check if test error codes are allowed
+     *
+     * @return bool
+     */
+    public function areTestCodesAllowed(): bool
+    {
+        return $this->allowTestCodes;
+    }
+
 
     /**
      * Retrieves the SOAP client that will be used to communicate with the VIES
@@ -251,7 +292,7 @@ class Vies
             throw new ViesException(sprintf('Invalid country code "%s" provided', $countryCode));
         }
 
-        if (in_array((int) $vatNumber, self::VIES_TEST_VAT_NRS, true)) {
+        if ($this->allowTestCodes && in_array((int) $vatNumber, self::VIES_TEST_VAT_NRS, true)) {
             return $this->validateTestVat($countryCode, $vatNumber);
         }
 

--- a/src/Vies/Vies.php
+++ b/src/Vies/Vies.php
@@ -88,7 +88,7 @@ class Vies
     /**
      * @var bool Require explicit checking against self::VIES_TEST_VAT_NRS
      */
-    protected $allowTestCodes = false;
+    protected $allowTestCodes = true;
 
     /**
      * @var SoapClient
@@ -292,7 +292,7 @@ class Vies
             throw new ViesException(sprintf('Invalid country code "%s" provided', $countryCode));
         }
 
-        if ($this->allowTestCodes && in_array((int) $vatNumber, self::VIES_TEST_VAT_NRS, true)) {
+        if ($this->areTestCodesAllowed() && in_array((int) $vatNumber, self::VIES_TEST_VAT_NRS, true)) {
             return $this->validateTestVat($countryCode, $vatNumber);
         }
 


### PR DESCRIPTION
Hi, I think it's possible for someone to pass the validator if the user of your package doesn't validate tax ids on their own as well. Specifically the \DragonBe\Vies\Vies instance method validate Vat always checks if the supplied $vatNumber is in the VIES_TEST_VAT_NRS array if so it performs the validation. Meaning someone could pass the valid 100 code and if a user doesn't perform any other checks the VAT number would be considered valid.

I propose an instance variable $allowTestCodes is added, with 3 methods supporting the turning of its state to true, false or getting the current state. In thing the flag should be turned of by default, this way only development environments are effected.

I also propose all error codes are included in the VIES_TEST_VAT_NRS. For instance I use a custom wrapper with custom error codes based on the error code returned, this allows me to provide localized translations of the error code and it would be nice to be able to test them without having to change the core files.