### PR TITLE
Informing users about problem validating UK VAT ID's

### DIFF
--- a/src/Vies/Vies.php
+++ b/src/Vies/Vies.php
@@ -87,6 +87,10 @@ class Vies
         'EU' => ['name' => 'MOSS Number', 'validator' => Validator\ValidatorEU::class],
     ];
 
+    protected const VIES_EXCLUDED_COUNTRY_CODES = [
+        'GB' => ['name' => 'United Kingdom', 'excluded' => '2021-01-01', 'reason' => 'Brexit'],
+    ];
+
     /**
      * @var bool Require explicit checking against self::VIES_TEST_VAT_NRS
      */
@@ -309,6 +313,15 @@ class Vies
             ];
 
             return new CheckVatResponse($params);
+        }
+
+        if (array_key_exists($countryCode, self::VIES_EXCLUDED_COUNTRY_CODES)) {
+            throw new ViesServiceException(sprintf(
+                'Country %s is no longer supported by VIES services provided by EC since %s because of %s',
+                self::VIES_EXCLUDED_COUNTRY_CODES[$countryCode]['name'],
+                self::VIES_EXCLUDED_COUNTRY_CODES[$countryCode]['excluded'],
+                self::VIES_EXCLUDED_COUNTRY_CODES[$countryCode]['reason'],
+            ));
         }
 
         $requestParams = [

--- a/tests/Vies/ViesTest.php
+++ b/tests/Vies/ViesTest.php
@@ -734,4 +734,38 @@ class ViesTest extends TestCase
         $vies = (new Vies())->disallowTestCodes();
         $this->assertFalse($vies->areTestCodesAllowed());
     }
+
+    public function excludedCountryProvider()
+    {
+        return [
+            'United Kingdom (Brexit 2021-01-01)' => ['GB', '244795376', 'United Kingdom', '2021-01-01', 'Brexit'],
+        ];
+    }
+
+    /**
+     * @param string $countryCode
+     * @param string $vatId
+     * @param string $country
+     * @param string $excluded
+     * @param string $reason
+     *
+     * @throws ViesException
+     * @throws ViesServiceException
+     *
+     * @covers ::validateVat
+     * @dataProvider excludedCountryProvider
+     */
+    public function testExcludedCountryVatValidation($countryCode, $vatId, $country, $excluded, $reason)
+    {
+        $exceptionMessage = sprintf(
+            'Country %s is no longer supported by VIES services provided by EC since %s because of %s',
+            $country,
+            $excluded,
+            $reason,
+        );
+        $this->expectException(ViesServiceException::class);
+        $this->expectExceptionMessage($exceptionMessage);
+        (new Vies())->validateVat($countryCode, $vatId);
+        $this->fail('Expected exception was not thrown');
+    }
 }


### PR DESCRIPTION
Issue #126: Instead of removing UK validation all together I now trigger a ViesServiceException to inform users can no longer validate VAT ID's from the United Kingdom. I believe this is an elegant transition rather than completely remove the validation for GB, because it is still possible to use the checksum validator.