### PR TITLE
Replace abandoned Sensiolabs security checker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "squizlabs/php_codesniffer": "^3.2",
         "phing/phing": "^2.16",
         "infection/infection": "^0.8",
-        "sensiolabs/security-checker": "^5.0"
+        "enlightn/security-checker": "^1.2"
     },
     "scripts": {
         "phpcs": "phpcs",


### PR DESCRIPTION
This PR replaces the abandoned [Sensiolabs security checker](https://github.com/sensiolabs/security-checker) with the [Enlightn security checker](https://github.com/enlightn/security-checker). 