### PR TITLE
Fix integer overflow on 32 bit architectures

### DIFF
--- a/src/Vies/Validator/ValidatorFR.php
+++ b/src/Vies/Validator/ValidatorFR.php
@@ -89,8 +89,15 @@ class ValidatorFR extends ValidatorAbstract
     private function validateOld(string $vatNumber): string
     {
         $checkVal = substr($vatNumber, 2);
+        if (! ctype_digit($checkVal)) {
+            return "";
+        }
         $checkVal .= "12";
-        $checkVal = intval($checkVal) % 97;
+        if (PHP_INT_SIZE === 4 && function_exists("bcmod")) {
+            $checkVal = (int) bcmod($checkVal, "97");
+        } else {
+            $checkVal = intval($checkVal) % 97;
+        }
 
         return $checkVal == 0 ? "00" : (string) $checkVal;
     }
@@ -112,6 +119,10 @@ class ValidatorFR extends ValidatorAbstract
         $checkCharacter = array_flip(str_split($this->alphabet));
         $checkVal = ($checkCharacter[$vatNumber[0]] * $multiplier) + $checkCharacter[$vatNumber[1]] - $subStractor;
 
-        return (((intval(substr($vatNumber, 2)) + ($checkVal / 11) + 1) % 11) == $checkVal % 11);
+        if (PHP_INT_SIZE === 4 && function_exists("bcmod")) {
+            return (int) bcmod(bcadd(substr($vatNumber, 2), strval(($checkVal / 11) + 1)), "11") === $checkVal % 11;
+        } else {
+            return ((intval(substr($vatNumber, 2)) + ($checkVal / 11) + 1) % 11) == $checkVal % 11;
+        }
     }
 }

--- a/src/Vies/Validator/ValidatorNL.php
+++ b/src/Vies/Validator/ValidatorNL.php
@@ -122,7 +122,7 @@ class ValidatorNL extends ValidatorAbstract
             return false;
         }
 
-        $sumBase = (int)array_reduce(str_split($vatNumber), function ($acc, $e) {
+        $sumBase = array_reduce(str_split($vatNumber), function ($acc, $e) {
             if (ctype_digit($e)) {
                 return $acc.$e;
             }
@@ -130,6 +130,10 @@ class ValidatorNL extends ValidatorAbstract
             return $acc.$this->checkCharacter[$e];
         }, '2321');
 
-        return ($sumBase % 97) === 1;
+        if (PHP_INT_SIZE === 4 && function_exists('bcmod')) {
+            return bcmod($sumBase, '97') === '1';
+        } else {
+            return ((int) $sumBase % 97) === 1;
+        }
     }
 }

--- a/src/Vies/Validator/ValidatorSK.php
+++ b/src/Vies/Validator/ValidatorSK.php
@@ -42,7 +42,13 @@ class ValidatorSK extends ValidatorAbstract
             return false;
         }
 
-        return in_array((int) $vatNumber[2], [2, 3, 4, 7, 8, 9])
-            && $vatNumber % 11 == 0;
+        if (in_array((int) $vatNumber[2], [2, 3, 4, 7, 8, 9])) {
+            if (PHP_INT_SIZE === 4 && function_exists('bcmod')) {
+                return bcmod($vatNumber, '11') === '0';
+            } else {
+                return $vatNumber % 11 == 0;
+            }
+        }
+        return false;
     }
 }

--- a/src/Vies/Validator/ValidatorSK.php
+++ b/src/Vies/Validator/ValidatorSK.php
@@ -34,21 +34,17 @@ class ValidatorSK extends ValidatorAbstract
      */
     public function validate(string $vatNumber): bool
     {
-        if (strlen($vatNumber) != 10) {
+        if (strlen($vatNumber) != 10
+            || intval($vatNumber[0]) == 0
+            || ! in_array((int) $vatNumber[2], [2, 3, 4, 7, 8, 9])
+        ) {
             return false;
         }
 
-        if (intval($vatNumber[0]) == 0) {
-            return false;
+        if (PHP_INT_SIZE === 4 && function_exists('bcmod')) {
+            return bcmod($vatNumber, '11') === '0';
+        } else {
+            return $vatNumber % 11 == 0;
         }
-
-        if (in_array((int) $vatNumber[2], [2, 3, 4, 7, 8, 9])) {
-            if (PHP_INT_SIZE === 4 && function_exists('bcmod')) {
-                return bcmod($vatNumber, '11') === '0';
-            } else {
-                return $vatNumber % 11 == 0;
-            }
-        }
-        return false;
     }
 }


### PR DESCRIPTION
This fixes FR's, NL's and SK's VATIN validations errors due to integer overflows on 32 bit platforms.