### PR TITLE
chore: add php8.1 to tests

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.4', '8.0']
+        php-versions: ['7.4', '8.0', '8.1']
 
     steps:
     - name: Set default PHP version ${{ matrix.php-versions }}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This project is on [Packagist](https://packagist.org/packages/dragonbe/vies)!
 
 To install the latest stable version use `composer require dragonbe/vies`.
 
-To install specifically a version (e.g. 2.0.4), just add it to the command above, for example `composer require dragonbe/vies:2.0.4`
+To install specifically a version (e.g. 2.2.0), just add it to the command above, for example `composer require dragonbe/vies:2.2.0`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ When you have implemented this service package in your own project, be sure that
 
 ## Requirements
 
-- Minimum PHP version: 7.1
+- Minimum PHP version: 7.3
 - Recommended PHP version: 7.4
 - Extension: soap
 - Extension: pcntl

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "pdepend/pdepend": "^2.5",
         "squizlabs/php_codesniffer": "^3.2",
         "phing/phing": "^2.16",
-        "infection/infection": "^0.20",
+        "infection/infection": "^0.25",
         "enlightn/security-checker": "^1.2"
     },
     "scripts": {

--- a/src/Vies/Validator/ValidatorFR.php
+++ b/src/Vies/Validator/ValidatorFR.php
@@ -122,7 +122,7 @@ class ValidatorFR extends ValidatorAbstract
         if (PHP_INT_SIZE === 4 && function_exists("bcmod")) {
             return (int) bcmod(bcadd(substr($vatNumber, 2), strval(($checkVal / 11) + 1)), "11") === $checkVal % 11;
         } else {
-            return ((intval(substr($vatNumber, 2)) + ($checkVal / 11) + 1) % 11) == $checkVal % 11;
+            return ((int)(intval(substr($vatNumber, 2)) + ($checkVal / 11) + 1) % 11) == $checkVal % 11;
         }
     }
 }

--- a/src/Vies/Validator/ValidatorFR.php
+++ b/src/Vies/Validator/ValidatorFR.php
@@ -93,7 +93,7 @@ class ValidatorFR extends ValidatorAbstract
             return "";
         }
         $checkVal .= "12";
-        if (PHP_INT_SIZE === 4 && function_exists("bcmod")) {
+        if (PHP_INT_SIZE === 4 && extension_loaded('bcmath')) {
             $checkVal = (int) bcmod($checkVal, "97");
         } else {
             $checkVal = intval($checkVal) % 97;
@@ -119,10 +119,10 @@ class ValidatorFR extends ValidatorAbstract
         $checkCharacter = array_flip(str_split($this->alphabet));
         $checkVal = ($checkCharacter[$vatNumber[0]] * $multiplier) + $checkCharacter[$vatNumber[1]] - $subStractor;
 
-        if (PHP_INT_SIZE === 4 && function_exists("bcmod")) {
+        if (PHP_INT_SIZE === 4 && extension_loaded("bcmath")) {
             return (int) bcmod(bcadd(substr($vatNumber, 2), strval(($checkVal / 11) + 1)), "11") === $checkVal % 11;
         } else {
-            return ((int)(intval(substr($vatNumber, 2)) + ($checkVal / 11) + 1) % 11) == $checkVal % 11;
+            return ((int) (intval(substr($vatNumber, 2)) + ($checkVal / 11) + 1) % 11) == $checkVal % 11;
         }
     }
 }

--- a/src/Vies/Validator/ValidatorNL.php
+++ b/src/Vies/Validator/ValidatorNL.php
@@ -130,7 +130,7 @@ class ValidatorNL extends ValidatorAbstract
             return $acc.$this->checkCharacter[$e];
         }, '2321');
 
-        if (PHP_INT_SIZE === 4 && function_exists('bcmod')) {
+        if (PHP_INT_SIZE === 4 && extension_loaded('bcmath')) {
             return bcmod($sumBase, '97') === '1';
         } else {
             return ((int) $sumBase % 97) === 1;

--- a/src/Vies/Validator/ValidatorSK.php
+++ b/src/Vies/Validator/ValidatorSK.php
@@ -41,7 +41,7 @@ class ValidatorSK extends ValidatorAbstract
             return false;
         }
 
-        if (PHP_INT_SIZE === 4 && function_exists('bcmod')) {
+        if (PHP_INT_SIZE === 4 && extension_loaded("bcmath")) {
             return bcmod($vatNumber, '11') === '0';
         } else {
             return $vatNumber % 11 == 0;

--- a/src/Vies/Vies.php
+++ b/src/Vies/Vies.php
@@ -463,7 +463,7 @@ class Vies
     private function filterArgument(string $argumentValue): string
     {
         $argumentValue = str_replace(['"', '\''], '', $argumentValue);
-        return filter_var($argumentValue, FILTER_SANITIZE_STRIPPED, FILTER_FLAG_STRIP_LOW);
+        return filter_var($argumentValue, FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW);
     }
 
     /**

--- a/tests/Vies/ViesTest.php
+++ b/tests/Vies/ViesTest.php
@@ -305,9 +305,15 @@ class ViesTest extends TestCase
         $vies = new Vies();
         $vies->setSoapClient($this->createdStubbedViesClient('blabla')->getSoapClient());
         $vies->setOptions($options);
-        $soapClient = $vies->getSoapClient();
-        $actual = $soapClient->_soap_version;
-        $this->assertSame($options['soap_version'], $actual);
+
+        /**
+         * Skip for php >=8.1.0 as _soap_version is private now
+         */
+        if (version_compare(PHP_VERSION, '8.1', '<')) {
+            $soapClient = $vies->getSoapClient();
+            $actual = $soapClient->_soap_version;
+            $this->assertSame($options['soap_version'], $actual);
+        }
         $this->assertSame($options, $vies->getOptions());
     }
 


### PR DESCRIPTION
Fixes for PHP 8.1
 - SoapClient _soap_version is now declared private so we need to skip this on tests
 - updated `infection/infection` package to latest version
 - `FILTER_SANITIZE_STRIPPED` is now deprecated
 - fixed some warnings about comparing float with int in ValidateFR class
 - use extension_loaded('bcmath') instead of function_exists('bcmod')