### PR TITLE
CY tax number can start with 6

### DIFF
--- a/src/Vies/Validator/ValidatorCY.php
+++ b/src/Vies/Validator/ValidatorCY.php
@@ -20,7 +20,7 @@ namespace DragonBe\Vies\Validator;
  * Range:
  *      C1 ... C8 Numeric from 0 to 9
  *      C9 Alphabetic
- *      C1 0, 1, 3, 4, 5, 9
+ *      C1 0, 1, 3, 4, 5, 6, 9
  *
  * Rules:
  * C1 C2
@@ -41,7 +41,7 @@ class ValidatorCY extends ValidatorAbstract
             return false;
         }
 
-        return in_array((int) $vatNumber[0], [0, 1, 3, 4, 5, 9], true)
+        return in_array((int) $vatNumber[0], [0, 1, 3, 4, 5, 6, 9], true)
             && ctype_alpha($vatNumber[8]);
     }
 }


### PR DESCRIPTION
Cyprus Tax Department now allows tax numbers starting with the number six

https://www.mof.gov.cy/mof/TAX/taxdep.nsf/All/A030E6F71B1D5F9AC22589A500453380?OpenDocument

https://www.mof.gov.cy/mof/TAX/taxdep.nsf/All/A030E6F71B1D5F9AC22589A500453380/$file/New%20TIN%20Format%2004052023.pdf