### PR TITLE
Fix PHP 8.5 Deprecations/Warnings and Modernize CI (Keeps PHP 7.3)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,42 +1,49 @@
 name: PHP Composer
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   build:
     name: ViesBuild
     runs-on: ${{ matrix.operating-system }}
+    # Let the experimental (next-PHP) leg fail without failing the workflow.
+    # Legs without an "experimental" value resolve to false and stay blocking.
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
+      fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.4', '8.0', '8.1']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        include:
+          # Forward-looking, non-blocking signal against the next PHP.
+          # This plugin exists to smooth installs on newer PHP, so an
+          # early-warning leg against the upcoming release fits its purpose.
+          -   operating-system: ubuntu-latest
+              php: '8.6'
+              experimental: true
 
     steps:
-    - name: Set default PHP version ${{ matrix.php-versions }}
+    - name: Set default PHP version ${{ matrix.php }}
       uses: shivammathur/setup-php@v2
       with:
-        php-version: "${{ matrix.php-versions }}"
+        php-version: "${{ matrix.php }}"
 
     - name: Display current PHP version
       run: php --version
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
 
     - name: Validate composer.json and composer.lock
       run: composer validate
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v5
       with:
         path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
         restore-keys: |
-          ${{ runner.os }}-php-
+          ${{ runner.os }}-php-${{ matrix.php }}-
 
     - name: Install dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'

--- a/src/Vies/Validator/ValidatorIE.php
+++ b/src/Vies/Validator/ValidatorIE.php
@@ -76,7 +76,9 @@ class ValidatorIE extends ValidatorAbstract
 
         $checkChar = 'A';
         for ($i = $checkVal - 1; $i > 0; $i--) {
-            $checkChar++;
+            // chr(ord(...) + 1) replaces $checkChar++ to avoid incrementing a
+            // non-numeric string, deprecated since PHP 8.3 (valid on PHP 7.3+).
+            $checkChar = chr(ord($checkChar) + 1);
         }
 
         return $checkChar == $checksum;

--- a/src/Vies/Validator/ValidatorSK.php
+++ b/src/Vies/Validator/ValidatorSK.php
@@ -35,6 +35,7 @@ class ValidatorSK extends ValidatorAbstract
     public function validate(string $vatNumber): bool
     {
         if (strlen($vatNumber) != 10
+            || ! ctype_digit($vatNumber)
             || intval($vatNumber[0]) == 0
             || ! in_array((int) $vatNumber[2], [2, 3, 4, 7, 8, 9])
         ) {

--- a/tests/Vies/Validator/ValidatorSKTest.php
+++ b/tests/Vies/Validator/ValidatorSKTest.php
@@ -4,6 +4,8 @@ declare (strict_types=1);
 
 namespace DragonBe\Test\Vies\Validator;
 
+use DragonBe\Vies\Validator\ValidatorSK;
+
 class ValidatorSKTest extends AbstractValidatorTest
 {
     /**
@@ -24,5 +26,26 @@ class ValidatorSKTest extends AbstractValidatorTest
             ['0123456789', false],
             ['4060000007', false],
         ];
+    }
+
+    /**
+     * @covers \DragonBe\Vies\Validator\ValidatorSK
+     */
+    public function testValidateRaisesNoWarningOnNonNumericInput()
+    {
+        $raised = null;
+        set_error_handler(static function (int $errno, string $errstr) use (&$raised): bool {
+            $raised = $errstr;
+            return true;
+        }, E_DEPRECATED | E_WARNING);
+
+        try {
+            $result = (new ValidatorSK())->validate('222222222A');
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertFalse($result, 'Non-numeric SK input must be invalid');
+        self::assertNull($raised, 'Validator must not trigger E_WARNING or E_DEPRECATED');
     }
 }

--- a/tests/Vies/ViesTest.php
+++ b/tests/Vies/ViesTest.php
@@ -389,7 +389,9 @@ class ViesTest extends TestCase
     {
         $viesRef = new \ReflectionClass(Vies::class);
         $addOptionalArguments = $viesRef->getMethod('addOptionalArguments');
-        $addOptionalArguments->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $addOptionalArguments->setAccessible(true);
+        }
 
         $array = [];
         $object = new Vies();
@@ -409,7 +411,9 @@ class ViesTest extends TestCase
     {
         $viesRef = new \ReflectionClass(Vies::class);
         $addOptionalArguments = $viesRef->getMethod('addOptionalArguments');
-        $addOptionalArguments->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $addOptionalArguments->setAccessible(true);
+        }
 
         $array = [];
         $object = new Vies();
@@ -484,7 +488,9 @@ class ViesTest extends TestCase
     ) {
         $viesRef = new \ReflectionClass(Vies::class);
         $addOptionalArguments = $viesRef->getMethod('addOptionalArguments');
-        $addOptionalArguments->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $addOptionalArguments->setAccessible(true);
+        }
 
         $array = [];
         $object = new Vies();
@@ -538,7 +544,9 @@ class ViesTest extends TestCase
     ) {
         $viesRef = new \ReflectionClass(Vies::class);
         $addOptionalArguments = $viesRef->getMethod('addOptionalArguments');
-        $addOptionalArguments->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $addOptionalArguments->setAccessible(true);
+        }
 
         $array = [];
         $object = new Vies();
@@ -561,7 +569,9 @@ class ViesTest extends TestCase
     {
         $viesRef = new \ReflectionClass(Vies::class);
         $addOptionalArguments = $viesRef->getMethod('addOptionalArguments');
-        $addOptionalArguments->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $addOptionalArguments->setAccessible(true);
+        }
 
         $this->expectException(\TypeError::class);
         $array = [];


### PR DESCRIPTION
Makes the package run cleanly on PHP 8.5 without dropping PHP 7.3 support (`composer.json` unchanged). No public API or behavior change for valid input.

- **ValidatorIE:** replace `$checkChar++` (increment on non-numeric string, deprecated in PHP 8.3) with `chr(ord($checkChar) + 1)`.
- **ViesTest:** guard `ReflectionMethod::setAccessible()` (deprecated in 8.5, no-op since 8.1) behind `PHP_VERSION_ID < 80100` — still required on < 8.1.
- **ValidatorSK:** add `! ctype_digit($vatNumber)` so malformed input returns `false` before the modulo instead of emitting a PHP 8 warning (+ regression test).
- **CI:** PHP 7.4–8.5 matrix plus a non-blocking 8.6 leg; `actions/*@v5`; per-PHP-version cache key; `fail-fast: false`.

Verified: `OK (252 tests, 450 assertions)`, all [actions](https://github.com/jonathanmaron/vies/actions) are green, zero deprecations/warnings from `src/` or `tests/` on 8.5; PHPCompatibility `7.3-8.5` and PSR-12 clean.